### PR TITLE
Refactoring for w3id PURLs

### DIFF
--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -2,6 +2,6 @@
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
     <uri id="Imports Wizard Entry" name="http://emmo.info/emmo/1.0.0-beta5" uri="https://raw.githubusercontent.com/emmo-repo/EMMO/1.0.0-beta5/emmo.ttl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=false, version=2" prefer="public" xml:base="">
-        <uri name="http://emmo.info/chemicalsubstance/0.1.0/chemicalsubstance" uri="./chemicalsubstance.ttl"/>
+        <uri name="https://w3id.org/emmo/domain/chemicalsubstance/0.2.0/chemicalsubstance" uri="./chemicalsubstance.ttl"/>
     </group>
 </catalog>

--- a/chemicalsubstance.ttl
+++ b/chemicalsubstance.ttl
@@ -1,4 +1,4 @@
-@prefix : <http://emmo.info/substance#> .
+@prefix : <https://w3id.org/emmo/chemicalsubstance#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
@@ -56,26 +56,26 @@ dcterms:source rdf:type owl:AnnotationProperty .
 #    Classes
 #################################################################
 
-###  http://emmo.info/substance#substance_0001e895_e74b_438f_b47f_b52f33d68331
+###  https://w3id.org/emmo/chemicalsubstance#substance_0001e895_e74b_438f_b47f_b52f33d68331
 :substance_0001e895_e74b_438f_b47f_b52f33d68331 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_fc93282d_cb35_4bab_81a8_78689ae59e5f ;
                                                 skos:prefLabel "MagnesiumSaltCompound"@en .
 
 
-###  http://emmo.info/substance#substance_001ca83b_5372_4d77_a836_4d48074b7e63
+###  https://w3id.org/emmo/chemicalsubstance#substance_001ca83b_5372_4d77_a836_4d48074b7e63
 :substance_001ca83b_5372_4d77_a836_4d48074b7e63 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "TitaniumOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_00db9ba1_7259_4180_a82e_7ed4dafc29a9
+###  https://w3id.org/emmo/chemicalsubstance#substance_00db9ba1_7259_4180_a82e_7ed4dafc29a9
 :substance_00db9ba1_7259_4180_a82e_7ed4dafc29a9 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 skos:altLabel "Mg(PF6)2"@en ;
                                                 skos:prefLabel "MagnesiumHexafluorophosphate"@en .
 
 
-###  http://emmo.info/substance#substance_0111ec52_b838_49ab_a24b_884aaa3f54e8
+###  https://w3id.org/emmo/chemicalsubstance#substance_0111ec52_b838_49ab_a24b_884aaa3f54e8
 :substance_0111ec52_b838_49ab_a24b_884aaa3f54e8 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_3540fb20_f719_42eb_ad0c_112ffedb7c6d ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q196661"@en ;
@@ -88,13 +88,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CadmiumOxide"@en .
 
 
-###  http://emmo.info/substance#substance_0111fe83_2d6c_4df0_9fd3_500ddda7242c
+###  https://w3id.org/emmo/chemicalsubstance#substance_0111fe83_2d6c_4df0_9fd3_500ddda7242c
 :substance_0111fe83_2d6c_4df0_9fd3_500ddda7242c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_61c88366_7689_4814_b0c5_1f53aef1eebd ;
                                                 skos:prefLabel "GalliumOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_012d4091_06bc_4089_bba4_b832200e69cd
+###  https://w3id.org/emmo/chemicalsubstance#substance_012d4091_06bc_4089_bba4_b832200e69cd
 :substance_012d4091_06bc_4089_bba4_b832200e69cd rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411260"@en ;
@@ -107,7 +107,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIICarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_0139937b_2724_4864_84fb_f14bcfb83538
+###  https://w3id.org/emmo/chemicalsubstance#substance_0139937b_2724_4864_84fb_f14bcfb83538
 :substance_0139937b_2724_4864_84fb_f14bcfb83538 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/129656524" ;
@@ -118,13 +118,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumManganeseOxide"@en .
 
 
-###  http://emmo.info/substance#substance_015116fe_94ca_4be5_9d14_9d9457a47a72
+###  https://w3id.org/emmo/chemicalsubstance#substance_015116fe_94ca_4be5_9d14_9d9457a47a72
 :substance_015116fe_94ca_4be5_9d14_9d9457a47a72 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_edae7b22_461b_432b_b737_3c93feb69b0e ;
                                                 skos:prefLabel "TransitionMetalSaltCompound"@en .
 
 
-###  http://emmo.info/substance#substance_02172b42_6e67_439c_93f4_42e7949268ce
+###  https://w3id.org/emmo/chemicalsubstance#substance_02172b42_6e67_439c_93f4_42e7949268ce
 :substance_02172b42_6e67_439c_93f4_42e7949268ce rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q114346676"@en ;
@@ -136,7 +136,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumBistrifluoromethanesulfonylimide"@en .
 
 
-###  http://emmo.info/substance#substance_0238c3cb_706f_4c5a_84e3_0738e16264bb
+###  https://w3id.org/emmo/chemicalsubstance#substance_0238c3cb_706f_4c5a_84e3_0738e16264bb
 :substance_0238c3cb_706f_4c5a_84e3_0738e16264bb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q447553"@en ;
@@ -148,7 +148,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumChlorate"@en .
 
 
-###  http://emmo.info/substance#substance_02ec30fa_cbca_4988_8c6b_6ec9f0cd138c
+###  https://w3id.org/emmo/chemicalsubstance#substance_02ec30fa_cbca_4988_8c6b_6ec9f0cd138c
 :substance_02ec30fa_cbca_4988_8c6b_6ec9f0cd138c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q422837"@en ;
@@ -161,7 +161,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIIAcetate"@en .
 
 
-###  http://emmo.info/substance#substance_032dde57_9fb4_4cd4_b212_282ff72ea152
+###  https://w3id.org/emmo/chemicalsubstance#substance_032dde57_9fb4_4cd4_b212_282ff72ea152
 :substance_032dde57_9fb4_4cd4_b212_282ff72ea152 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q161233"@en ;
@@ -174,13 +174,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "FormicAcid"@en .
 
 
-###  http://emmo.info/substance#substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5
+###  https://w3id.org/emmo/chemicalsubstance#substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5
 :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_015116fe_94ca_4be5_9d14_9d9457a47a72 ;
                                                 skos:prefLabel "LeadSaltCompound"@en .
 
 
-###  http://emmo.info/substance#substance_0391f63f_9ab8_4b33_a4c5_47591a89de72
+###  https://w3id.org/emmo/chemicalsubstance#substance_0391f63f_9ab8_4b33_a4c5_47591a89de72
 :substance_0391f63f_9ab8_4b33_a4c5_47591a89de72 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q324628"@en ;
@@ -192,7 +192,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AcrylicAcid"@en .
 
 
-###  http://emmo.info/substance#substance_046a3fb1_cd54_4014_afd0_908a8ad1da5e
+###  https://w3id.org/emmo/chemicalsubstance#substance_046a3fb1_cd54_4014_afd0_908a8ad1da5e
 :substance_046a3fb1_cd54_4014_afd0_908a8ad1da5e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q79739"@en ;
@@ -207,7 +207,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "GammaButyrolactone"@en .
 
 
-###  http://emmo.info/substance#substance_046acf7e_3390_484c_8c7e_7cf2a331fb3b
+###  https://w3id.org/emmo/chemicalsubstance#substance_046acf7e_3390_484c_8c7e_7cf2a331fb3b
 :substance_046acf7e_3390_484c_8c7e_7cf2a331fb3b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q417121"@en ;
@@ -220,7 +220,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIIFluoride"@en .
 
 
-###  http://emmo.info/substance#substance_0470d73a_ea51_4505_b164_0c090bf0382b
+###  https://w3id.org/emmo/chemicalsubstance#substance_0470d73a_ea51_4505_b164_0c090bf0382b
 :substance_0470d73a_ea51_4505_b164_0c090bf0382b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4737377"@en ;
@@ -233,7 +233,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumCarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_04a7bd93_0a55_444b_a28e_33b01ee0bc4e
+###  https://w3id.org/emmo/chemicalsubstance#substance_04a7bd93_0a55_444b_a28e_33b01ee0bc4e
 :substance_04a7bd93_0a55_444b_a28e_33b01ee0bc4e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q286064"@en ;
@@ -246,7 +246,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIINitrate"@en .
 
 
-###  http://emmo.info/substance#substance_04ad7fec_b260_4d25_9c6e_47711c0f8a46
+###  https://w3id.org/emmo/chemicalsubstance#substance_04ad7fec_b260_4d25_9c6e_47711c0f8a46
 :substance_04ad7fec_b260_4d25_9c6e_47711c0f8a46 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "http://127.0.0.1:5000/compounds/23290296"@en ;
@@ -258,14 +258,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MOEMC"@en .
 
 
-###  http://emmo.info/substance#substance_05b11934_6a3e_4434_855b_111aced0a6be
+###  https://w3id.org/emmo/chemicalsubstance#substance_05b11934_6a3e_4434_855b_111aced0a6be
 :substance_05b11934_6a3e_4434_855b_111aced0a6be rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 skos:altLabel "Ba(TFSI)2"@en ;
                                                 skos:prefLabel "BariumBistrifluoromethanesulfonylimide"@en .
 
 
-###  http://emmo.info/substance#substance_08695cfe_3dfa_4b17_9f09_13e6f90e3875
+###  https://w3id.org/emmo/chemicalsubstance#substance_08695cfe_3dfa_4b17_9f09_13e6f90e3875
 :substance_08695cfe_3dfa_4b17_9f09_13e6f90e3875 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/101611500" ;
@@ -276,7 +276,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIINitrite"@en .
 
 
-###  http://emmo.info/substance#substance_09338922_833a_406c_be2c_4098980cabc3
+###  https://w3id.org/emmo/chemicalsubstance#substance_09338922_833a_406c_be2c_4098980cabc3
 :substance_09338922_833a_406c_be2c_4098980cabc3 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4096881"@en ;
@@ -289,13 +289,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIIBromide"@en .
 
 
-###  http://emmo.info/substance#substance_094f08bc_90ea_4118_b136_47e61e495ab5
+###  https://w3id.org/emmo/chemicalsubstance#substance_094f08bc_90ea_4118_b136_47e61e495ab5
 :substance_094f08bc_90ea_4118_b136_47e61e495ab5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_015116fe_94ca_4be5_9d14_9d9457a47a72 ;
                                                 skos:prefLabel "CopperSaltCompound"@en .
 
 
-###  http://emmo.info/substance#substance_0952b0ae_0067_4b42_812a_abb68c95a6f8
+###  https://w3id.org/emmo/chemicalsubstance#substance_0952b0ae_0067_4b42_812a_abb68c95a6f8
 :substance_0952b0ae_0067_4b42_812a_abb68c95a6f8 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/2734307" ;
@@ -306,7 +306,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumTriflate"@en .
 
 
-###  http://emmo.info/substance#substance_0993cbab_ff7f_4ec3_8a6c_cd67497d54d9
+###  https://w3id.org/emmo/chemicalsubstance#substance_0993cbab_ff7f_4ec3_8a6c_cd67497d54d9
 :substance_0993cbab_ff7f_4ec3_8a6c_cd67497d54d9 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -319,14 +319,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Copper"@en .
 
 
-###  http://emmo.info/substance#substance_09aa1409_b244_4d5e_a6ed_c94bdff60e42
+###  https://w3id.org/emmo/chemicalsubstance#substance_09aa1409_b244_4d5e_a6ed_c94bdff60e42
 :substance_09aa1409_b244_4d5e_a6ed_c94bdff60e42 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 skos:altLabel "Mn(ClO3)2"@en ;
                                                 skos:prefLabel "ManganeseIIChlorate"@en .
 
 
-###  http://emmo.info/substance#substance_09c627db_bca7_4a25_9233_90af4e22505e
+###  https://w3id.org/emmo/chemicalsubstance#substance_09c627db_bca7_4a25_9233_90af4e22505e
 :substance_09c627db_bca7_4a25_9233_90af4e22505e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_878a0e2f_12ba_484e_8197_75e57139d207 ,
                                                                 :substance_961f7671_8708_4ce3_9c7d_79444adba9c0 ;
@@ -340,7 +340,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Methanol"@en .
 
 
-###  http://emmo.info/substance#substance_09e14ca2_f909_40cc_ba93_e1a149938abc
+###  https://w3id.org/emmo/chemicalsubstance#substance_09e14ca2_f909_40cc_ba93_e1a149938abc
 :substance_09e14ca2_f909_40cc_ba93_e1a149938abc rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bed1a22c_8b61_467a_86a0_d24c7b910653 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q182849"@en ;
@@ -353,7 +353,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumHydroxide"@en .
 
 
-###  http://emmo.info/substance#substance_09e44ba7_e928_4aa8_aa50_484742e6965c
+###  https://w3id.org/emmo/chemicalsubstance#substance_09e44ba7_e928_4aa8_aa50_484742e6965c
 :substance_09e44ba7_e928_4aa8_aa50_484742e6965c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72482882"@en ;
@@ -365,7 +365,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIITetrafluoroborate"@en .
 
 
-###  http://emmo.info/substance#substance_0a5cb747_60cf_4929_a54a_712c54b49f3b
+###  https://w3id.org/emmo/chemicalsubstance#substance_0a5cb747_60cf_4929_a54a_712c54b49f3b
 :substance_0a5cb747_60cf_4929_a54a_712c54b49f3b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_6c0cc397_d8c4_4473_a09f_1e5de568e0dd ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q764245"@en ;
@@ -373,14 +373,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CarbonBlack"@en .
 
 
-###  http://emmo.info/substance#substance_0a6ddace_69a9_43af_8cb1_bf1fcfaaea67
+###  https://w3id.org/emmo/chemicalsubstance#substance_0a6ddace_69a9_43af_8cb1_bf1fcfaaea67
 :substance_0a6ddace_69a9_43af_8cb1_bf1fcfaaea67 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 skos:altLabel "NaBOP"@en ;
                                                 skos:prefLabel "SodiumBisoxalatophosphate"@en .
 
 
-###  http://emmo.info/substance#substance_0aae472b_b322_43c4_991f_e4ec88f52f3e
+###  https://w3id.org/emmo/chemicalsubstance#substance_0aae472b_b322_43c4_991f_e4ec88f52f3e
 :substance_0aae472b_b322_43c4_991f_e4ec88f52f3e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72482889"@en ;
@@ -392,7 +392,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIITriflate"@en .
 
 
-###  http://emmo.info/substance#substance_0bdf0bb9_41fc_455d_af11_a249e24acdf6
+###  https://w3id.org/emmo/chemicalsubstance#substance_0bdf0bb9_41fc_455d_af11_a249e24acdf6
 :substance_0bdf0bb9_41fc_455d_af11_a249e24acdf6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/13710615" ;
@@ -402,13 +402,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumCobaltPhosphate"@en .
 
 
-###  http://emmo.info/substance#substance_0dcf209c_6455_4305_9714_fec548742c6a
+###  https://w3id.org/emmo/chemicalsubstance#substance_0dcf209c_6455_4305_9714_fec548742c6a
 :substance_0dcf209c_6455_4305_9714_fec548742c6a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "PalladiumOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_0deb4fe8_b0c0_4e3f_8848_64435e5c0771
+###  https://w3id.org/emmo/chemicalsubstance#substance_0deb4fe8_b0c0_4e3f_8848_64435e5c0771
 :substance_0deb4fe8_b0c0_4e3f_8848_64435e5c0771 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2583808"@en ;
@@ -421,7 +421,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumHexafluorophosphate"@en .
 
 
-###  http://emmo.info/substance#substance_0e21b44e_5749_4b19_9d79_d8b70df1cdc6
+###  https://w3id.org/emmo/chemicalsubstance#substance_0e21b44e_5749_4b19_9d79_d8b70df1cdc6
 :substance_0e21b44e_5749_4b19_9d79_d8b70df1cdc6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_de038959_9251_48d1_a141_3684f14d957f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407125"@en ;
@@ -434,7 +434,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumHydroxide"@en .
 
 
-###  http://emmo.info/substance#substance_0e235e95_739d_443a_ad4b_97ef1edb9c89
+###  https://w3id.org/emmo/chemicalsubstance#substance_0e235e95_739d_443a_ad4b_97ef1edb9c89
 :substance_0e235e95_739d_443a_ad4b_97ef1edb9c89 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2234483"@en ;
@@ -448,7 +448,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Dioxolane"@en .
 
 
-###  http://emmo.info/substance#substance_0f29d712_f329_4b17_abeb_5df9bf4fb321
+###  https://w3id.org/emmo/chemicalsubstance#substance_0f29d712_f329_4b17_abeb_5df9bf4fb321
 :substance_0f29d712_f329_4b17_abeb_5df9bf4fb321 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -461,7 +461,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Technetium"@en .
 
 
-###  http://emmo.info/substance#substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1
+###  https://w3id.org/emmo/chemicalsubstance#substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1
 :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q146505" ;
@@ -478,7 +478,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
  ] .
 
 
-###  http://emmo.info/substance#substance_1285bd02_b0c1_45cb_8895_6ae6517f86a1
+###  https://w3id.org/emmo/chemicalsubstance#substance_1285bd02_b0c1_45cb_8895_6ae6517f86a1
 :substance_1285bd02_b0c1_45cb_8895_6ae6517f86a1 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q422956"@en ;
@@ -490,7 +490,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PropionicAcid"@en .
 
 
-###  http://emmo.info/substance#substance_12f3fc79_fc8f_44a1_8736_945e03392abe
+###  https://w3id.org/emmo/chemicalsubstance#substance_12f3fc79_fc8f_44a1_8736_945e03392abe
 :substance_12f3fc79_fc8f_44a1_8736_945e03392abe rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/15976041" ;
@@ -501,7 +501,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIIBistrifluoromethanesulfonylimide"@en .
 
 
-###  http://emmo.info/substance#substance_13eaf787_000e_44f8_b939_332101e81dd2
+###  https://w3id.org/emmo/chemicalsubstance#substance_13eaf787_000e_44f8_b939_332101e81dd2
 :substance_13eaf787_000e_44f8_b939_332101e81dd2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q60568753"@en ;
@@ -514,19 +514,19 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIIPhosphate"@en .
 
 
-###  http://emmo.info/substance#substance_155e894b_66de_4cda_9dbe_adbeca7d8102
+###  https://w3id.org/emmo/chemicalsubstance#substance_155e894b_66de_4cda_9dbe_adbeca7d8102
 :substance_155e894b_66de_4cda_9dbe_adbeca7d8102 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "TinOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_15d08ff9_7685_4020_8481_d9c9b0052176
+###  https://w3id.org/emmo/chemicalsubstance#substance_15d08ff9_7685_4020_8481_d9c9b0052176
 :substance_15d08ff9_7685_4020_8481_d9c9b0052176 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ;
                                                 skos:prefLabel "MixedMetalOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_16864b33_aa8e_451d_ad8e_b0af5f18769a
+###  https://w3id.org/emmo/chemicalsubstance#substance_16864b33_aa8e_451d_ad8e_b0af5f18769a
 :substance_16864b33_aa8e_451d_ad8e_b0af5f18769a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q278332"@en ;
@@ -540,7 +540,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Tetrahydrofuran"@en .
 
 
-###  http://emmo.info/substance#substance_16d7c7a6_56ef_429b_9ce8_cd911410d083
+###  https://w3id.org/emmo/chemicalsubstance#substance_16d7c7a6_56ef_429b_9ce8_cd911410d083
 :substance_16d7c7a6_56ef_429b_9ce8_cd911410d083 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/203099" ;
@@ -551,7 +551,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumTetrafluoroborate"@en .
 
 
-###  http://emmo.info/substance#substance_177b95f8_2816_43de_94bb_1a1054c45e32
+###  https://w3id.org/emmo/chemicalsubstance#substance_177b95f8_2816_43de_94bb_1a1054c45e32
 :substance_177b95f8_2816_43de_94bb_1a1054c45e32 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_8e5448fc_1916_4afb_9fd9_2489797f6922 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204820"@en ;
@@ -561,7 +561,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincHydroxide"@en .
 
 
-###  http://emmo.info/substance#substance_17c30663_ccc8_45b0_b713_9bd095e20ebd
+###  https://w3id.org/emmo/chemicalsubstance#substance_17c30663_ccc8_45b0_b713_9bd095e20ebd
 :substance_17c30663_ccc8_45b0_b713_9bd095e20ebd rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q15628085"@en ;
@@ -574,7 +574,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIIPerchlorate"@en .
 
 
-###  http://emmo.info/substance#substance_191c3c02_4930_44d4_bf20_0d79ed41f8c5
+###  https://w3id.org/emmo/chemicalsubstance#substance_191c3c02_4930_44d4_bf20_0d79ed41f8c5
 :substance_191c3c02_4930_44d4_bf20_0d79ed41f8c5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/18760923" ;
@@ -586,7 +586,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIISulfite"@en .
 
 
-###  http://emmo.info/substance#substance_19292fbf_8a09_45a0_b807_f643253a333c
+###  https://w3id.org/emmo/chemicalsubstance#substance_19292fbf_8a09_45a0_b807_f643253a333c
 :substance_19292fbf_8a09_45a0_b807_f643253a333c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f5b930f9_2f95_4268_993c_ff6b57ae7691 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q138809"@en ;
@@ -599,7 +599,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ChloricAcid"@en .
 
 
-###  http://emmo.info/substance#substance_1988f19c_c06b_44ab_817e_dd23b9dfd9d5
+###  https://w3id.org/emmo/chemicalsubstance#substance_1988f19c_c06b_44ab_817e_dd23b9dfd9d5
 :substance_1988f19c_c06b_44ab_817e_dd23b9dfd9d5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0111fe83_2d6c_4df0_9fd3_500ddda7242c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q419487"@en ;
@@ -612,7 +612,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "GalliumOxide"@en .
 
 
-###  http://emmo.info/substance#substance_19f88cb6_57a8_4111_9d73_6b58dce0ba76
+###  https://w3id.org/emmo/chemicalsubstance#substance_19f88cb6_57a8_4111_9d73_6b58dce0ba76
 :substance_19f88cb6_57a8_4111_9d73_6b58dce0ba76 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204713"@en ;
@@ -625,7 +625,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincCyanide"@en .
 
 
-###  http://emmo.info/substance#substance_1b31f3bb_1c1b_40e2_8d0f_0e21abe237e7
+###  https://w3id.org/emmo/chemicalsubstance#substance_1b31f3bb_1c1b_40e2_8d0f_0e21abe237e7
 :substance_1b31f3bb_1c1b_40e2_8d0f_0e21abe237e7 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q27861942"@en ;
@@ -638,14 +638,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumAcetate"@en .
 
 
-###  http://emmo.info/substance#substance_1be34841_81f7_4216_8290_6bd75361a1c9
+###  https://w3id.org/emmo/chemicalsubstance#substance_1be34841_81f7_4216_8290_6bd75361a1c9
 :substance_1be34841_81f7_4216_8290_6bd75361a1c9 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 skos:altLabel "NaTFOB"@en ;
                                                 skos:prefLabel "SodiumTrifluoromethanesulfonyloxalatoborate"@en .
 
 
-###  http://emmo.info/substance#substance_1c24293c_3a09_4084_a6bb_0db9fae5e786
+###  https://w3id.org/emmo/chemicalsubstance#substance_1c24293c_3a09_4084_a6bb_0db9fae5e786
 :substance_1c24293c_3a09_4084_a6bb_0db9fae5e786 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q28457468"@en ;
@@ -658,7 +658,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Tris222TrifluoroethylBorate"@en .
 
 
-###  http://emmo.info/substance#substance_1d8e9a99_b998_47e6_98a7_a6efd8dab9ce
+###  https://w3id.org/emmo/chemicalsubstance#substance_1d8e9a99_b998_47e6_98a7_a6efd8dab9ce
 :substance_1d8e9a99_b998_47e6_98a7_a6efd8dab9ce rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_6c0cc397_d8c4_4473_a09f_1e5de568e0dd ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1997"@en ;
@@ -670,7 +670,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CarbonDioxide"@en .
 
 
-###  http://emmo.info/substance#substance_1dd8fd65_919b_40d1_a78c_9409b28e323e
+###  https://w3id.org/emmo/chemicalsubstance#substance_1dd8fd65_919b_40d1_a78c_9409b28e323e
 :substance_1dd8fd65_919b_40d1_a78c_9409b28e323e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q414189"@en ;
@@ -685,7 +685,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MethylAcetate"@en .
 
 
-###  http://emmo.info/substance#substance_1dfa4556_49d2_494c_971d_bd193219e9b2
+###  https://w3id.org/emmo/chemicalsubstance#substance_1dfa4556_49d2_494c_971d_bd193219e9b2
 :substance_1dfa4556_49d2_494c_971d_bd193219e9b2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411337"@en ;
@@ -698,7 +698,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIISulfate"@en .
 
 
-###  http://emmo.info/substance#substance_1e30dcc6_b1c7_4fe9_8f36_1dd427c78a93
+###  https://w3id.org/emmo/chemicalsubstance#substance_1e30dcc6_b1c7_4fe9_8f36_1dd427c78a93
 :substance_1e30dcc6_b1c7_4fe9_8f36_1dd427c78a93 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q20670642"@en ;
@@ -710,14 +710,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincSulfite"@en .
 
 
-###  http://emmo.info/substance#substance_1e5c69b2_6dac_44b6_a24e_6170b516cf2c
+###  https://w3id.org/emmo/chemicalsubstance#substance_1e5c69b2_6dac_44b6_a24e_6170b516cf2c
 :substance_1e5c69b2_6dac_44b6_a24e_6170b516cf2c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 skos:altLabel "Ca(BOP)2"@en ;
                                                 skos:prefLabel "CalciumBisoxalatophosphate"@en .
 
 
-###  http://emmo.info/substance#substance_20004d19_02cf_4667_a09f_b5c595b44b1f
+###  https://w3id.org/emmo/chemicalsubstance#substance_20004d19_02cf_4667_a09f_b5c595b44b1f
 :substance_20004d19_02cf_4667_a09f_b5c595b44b1f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/2769656" ;
@@ -728,7 +728,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "FluoroethyleneCarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_20319b23_0673_45de_9b12_794813d948a9
+###  https://w3id.org/emmo/chemicalsubstance#substance_20319b23_0673_45de_9b12_794813d948a9
 :substance_20319b23_0673_45de_9b12_794813d948a9 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a9a6507f_9c61_44d3_bd86_f1ebf763e150 ;
@@ -741,7 +741,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Arsenic"@en .
 
 
-###  http://emmo.info/substance#substance_210edf30_ad63_438c_97db_f817942db49b
+###  https://w3id.org/emmo/chemicalsubstance#substance_210edf30_ad63_438c_97db_f817942db49b
 :substance_210edf30_ad63_438c_97db_f817942db49b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7e716191_b301_4d63_bb6b_93323ffe51bf ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q146429"@en ;
@@ -754,7 +754,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StyreneButadiene"@en .
 
 
-###  http://emmo.info/substance#substance_21954b0b_c05c_42db_b276_3a931d8aabb1
+###  https://w3id.org/emmo/chemicalsubstance#substance_21954b0b_c05c_42db_b276_3a931d8aabb1
 :substance_21954b0b_c05c_42db_b276_3a931d8aabb1 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411496"@en ;
@@ -769,7 +769,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Dimethoxymethane"@en .
 
 
-###  http://emmo.info/substance#substance_22796803_c3b7_4e24_b6f9_7f65d453b01a
+###  https://w3id.org/emmo/chemicalsubstance#substance_22796803_c3b7_4e24_b6f9_7f65d453b01a
 :substance_22796803_c3b7_4e24_b6f9_7f65d453b01a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f7d13311_6dd1_422c_b32b_b55fd9e77145 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407709"@en ;
@@ -782,7 +782,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_22a9ed4c_0e7b_4f40_93e5_6aa9ecda1fff
+###  https://w3id.org/emmo/chemicalsubstance#substance_22a9ed4c_0e7b_4f40_93e5_6aa9ecda1fff
 :substance_22a9ed4c_0e7b_4f40_93e5_6aa9ecda1fff rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409373"@en ;
@@ -795,7 +795,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "GlycolicAcid"@en .
 
 
-###  http://emmo.info/substance#substance_23145a95_d51a_471c_8f5c_ec1a970b3798
+###  https://w3id.org/emmo/chemicalsubstance#substance_23145a95_d51a_471c_8f5c_ec1a970b3798
 :substance_23145a95_d51a_471c_8f5c_ec1a970b3798 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1674310"@en ;
@@ -808,7 +808,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumAcetate"@en .
 
 
-###  http://emmo.info/substance#substance_231feb61_4200_4bc7_b060_02b51ab13ee2
+###  https://w3id.org/emmo/chemicalsubstance#substance_231feb61_4200_4bc7_b060_02b51ab13ee2
 :substance_231feb61_4200_4bc7_b060_02b51ab13ee2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q410203"@en ;
@@ -821,7 +821,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumPerchlorate"@en .
 
 
-###  http://emmo.info/substance#substance_244fbc5c_41d5_42aa_b078_019cb0b2f3b7
+###  https://w3id.org/emmo/chemicalsubstance#substance_244fbc5c_41d5_42aa_b078_019cb0b2f3b7
 :substance_244fbc5c_41d5_42aa_b078_019cb0b2f3b7 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4321583"@en ;
@@ -834,7 +834,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIINitrate"@en .
 
 
-###  http://emmo.info/substance#substance_24bb590f_86c4_4fd9_ac4e_ef89a43d0fb1
+###  https://w3id.org/emmo/chemicalsubstance#substance_24bb590f_86c4_4fd9_ac4e_ef89a43d0fb1
 :substance_24bb590f_86c4_4fd9_ac4e_ef89a43d0fb1 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_de038959_9251_48d1_a141_3684f14d957f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q410563"@en ;
@@ -847,7 +847,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ChromiumHydroxide"@en .
 
 
-###  http://emmo.info/substance#substance_250fa43e_1f26_4ed8_b787_91a2325a8e7b
+###  https://w3id.org/emmo/chemicalsubstance#substance_250fa43e_1f26_4ed8_b787_91a2325a8e7b
 :substance_250fa43e_1f26_4ed8_b787_91a2325a8e7b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f7d13311_6dd1_422c_b32b_b55fd9e77145 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421787"@en ;
@@ -860,7 +860,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_25f6ff4c_53ad_4837_97c4_aa6f06099bb5
+###  https://w3id.org/emmo/chemicalsubstance#substance_25f6ff4c_53ad_4837_97c4_aa6f06099bb5
 :substance_25f6ff4c_53ad_4837_97c4_aa6f06099bb5 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -873,7 +873,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Platinum"@en .
 
 
-###  http://emmo.info/substance#substance_26452118_db69_4a2f_a862_2cebe1f6c85f
+###  https://w3id.org/emmo/chemicalsubstance#substance_26452118_db69_4a2f_a862_2cebe1f6c85f
 :substance_26452118_db69_4a2f_a862_2cebe1f6c85f rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/102470862" ;
@@ -883,7 +883,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BPFPB"@en .
 
 
-###  http://emmo.info/substance#substance_26727c25_d619_4c2b_8699_a79be9c07bd5
+###  https://w3id.org/emmo/chemicalsubstance#substance_26727c25_d619_4c2b_8699_a79be9c07bd5
 :substance_26727c25_d619_4c2b_8699_a79be9c07bd5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q390305"@en ;
@@ -896,14 +896,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumIodide"@en .
 
 
-###  http://emmo.info/substance#substance_27696fcd_aa90_44b9_816a_c19400f0ab9a
+###  https://w3id.org/emmo/chemicalsubstance#substance_27696fcd_aa90_44b9_816a_c19400f0ab9a
 :substance_27696fcd_aa90_44b9_816a_c19400f0ab9a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 skos:altLabel "Mg(BOB)2"@en ;
                                                 skos:prefLabel "MagnesiumBisoxalatoborate"@en .
 
 
-###  http://emmo.info/substance#substance_2773ee9b_cee9_4367_8b81_4ce6265d411a
+###  https://w3id.org/emmo/chemicalsubstance#substance_2773ee9b_cee9_4367_8b81_4ce6265d411a
 :substance_2773ee9b_cee9_4367_8b81_4ce6265d411a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1392795"@en ;
@@ -916,7 +916,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumChlorate"@en .
 
 
-###  http://emmo.info/substance#substance_27b3d761_128f_4480_8d84_498160a3dfac
+###  https://w3id.org/emmo/chemicalsubstance#substance_27b3d761_128f_4480_8d84_498160a3dfac
 :substance_27b3d761_128f_4480_8d84_498160a3dfac rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1910594"@en ;
@@ -929,7 +929,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumHexafluorophosphate"@en .
 
 
-###  http://emmo.info/substance#substance_27f50595_4b06_478b_8a93_877ea00c943a
+###  https://w3id.org/emmo/chemicalsubstance#substance_27f50595_4b06_478b_8a93_877ea00c943a
 :substance_27f50595_4b06_478b_8a93_877ea00c943a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c7bab57c_23c4_41d7_b2dc_497683fc82db ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409279"@en ;
@@ -942,13 +942,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "RhodiumIVOxide"@en .
 
 
-###  http://emmo.info/substance#substance_28754642_a1ed_4f39_8b00_2c7857336bab
+###  https://w3id.org/emmo/chemicalsubstance#substance_28754642_a1ed_4f39_8b00_2c7857336bab
 :substance_28754642_a1ed_4f39_8b00_2c7857336bab rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "ZincOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_28899817_2002_42d8_92bf_b43d2cf7b4c6
+###  https://w3id.org/emmo/chemicalsubstance#substance_28899817_2002_42d8_92bf_b43d2cf7b4c6
 :substance_28899817_2002_42d8_92bf_b43d2cf7b4c6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q104334"@en ;
@@ -961,7 +961,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CarbonicAcid"@en .
 
 
-###  http://emmo.info/substance#substance_28df7242_f3a7_44e5_bd60_fb16796539c1
+###  https://w3id.org/emmo/chemicalsubstance#substance_28df7242_f3a7_44e5_bd60_fb16796539c1
 :substance_28df7242_f3a7_44e5_bd60_fb16796539c1 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_78400dc0_97b0_4d59_8ea6_30bb703f428c ;
@@ -975,7 +975,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Oxygen"@en .
 
 
-###  http://emmo.info/substance#substance_29611fc5_9fc1_486b_bdbb_33bb8b3ee916
+###  https://w3id.org/emmo/chemicalsubstance#substance_29611fc5_9fc1_486b_bdbb_33bb8b3ee916
 :substance_29611fc5_9fc1_486b_bdbb_33bb8b3ee916 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q415520"@en ;
@@ -988,7 +988,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIIIodide"@en .
 
 
-###  http://emmo.info/substance#substance_29b1c15d_2632_40d7_88f7_43575b68b988
+###  https://w3id.org/emmo/chemicalsubstance#substance_29b1c15d_2632_40d7_88f7_43575b68b988
 :substance_29b1c15d_2632_40d7_88f7_43575b68b988 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_8e5448fc_1916_4afb_9fd9_2489797f6922 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72461179"@en ;
@@ -1001,7 +1001,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltHydroxide"@en .
 
 
-###  http://emmo.info/substance#substance_29dc7a8a_95a6_467c_baa1_25f6a20a5ebe
+###  https://w3id.org/emmo/chemicalsubstance#substance_29dc7a8a_95a6_467c_baa1_25f6a20a5ebe
 :substance_29dc7a8a_95a6_467c_baa1_25f6a20a5ebe rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411214"@en ;
@@ -1014,7 +1014,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIISulfate"@en .
 
 
-###  http://emmo.info/substance#substance_29eddf3b_c99a_4624_a520_dc7983da27e0
+###  https://w3id.org/emmo/chemicalsubstance#substance_29eddf3b_c99a_4624_a520_dc7983da27e0
 :substance_29eddf3b_c99a_4624_a520_dc7983da27e0 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q416246"@en ;
@@ -1027,7 +1027,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIIBromide"@en .
 
 
-###  http://emmo.info/substance#substance_29ee50d4_27ed_4228_bd26_0010d9310f03
+###  https://w3id.org/emmo/chemicalsubstance#substance_29ee50d4_27ed_4228_bd26_0010d9310f03
 :substance_29ee50d4_27ed_4228_bd26_0010d9310f03 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/8179" ;
@@ -1038,13 +1038,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "DiethyleneGlycolDiethylEther"@en .
 
 
-###  http://emmo.info/substance#substance_29fd347b_6a15_4c98_a982_84cf555b0b86
+###  https://w3id.org/emmo/chemicalsubstance#substance_29fd347b_6a15_4c98_a982_84cf555b0b86
 :substance_29fd347b_6a15_4c98_a982_84cf555b0b86 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cc155ed5_c60c_4d9f_bfad_fbf6b7c77e57 ;
                                                 skos:prefLabel "WeakAcid"@en .
 
 
-###  http://emmo.info/substance#substance_2a540939_3908_4f85_92f9_c46da7d4e9cb
+###  https://w3id.org/emmo/chemicalsubstance#substance_2a540939_3908_4f85_92f9_c46da7d4e9cb
 :substance_2a540939_3908_4f85_92f9_c46da7d4e9cb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f24cfd50_5d01_4e02_88b5_44a609cfa432 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407815"@en ;
@@ -1057,7 +1057,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SilverIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_2a87ca10_fc6a_4d61_b48c_d9790a566ee3
+###  https://w3id.org/emmo/chemicalsubstance#substance_2a87ca10_fc6a_4d61_b48c_d9790a566ee3
 :substance_2a87ca10_fc6a_4d61_b48c_d9790a566ee3 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_8f1af9c2_9b6d_44f4_8f55_70a4cd5f9dde ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q424955"@en ;
@@ -1070,7 +1070,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_2aace708_cc53_4cc4_bf71_8e09f6521e51
+###  https://w3id.org/emmo/chemicalsubstance#substance_2aace708_cc53_4cc4_bf71_8e09f6521e51
 :substance_2aace708_cc53_4cc4_bf71_8e09f6521e51 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_68e4028b_0ec6_46da_8d1c_d00c644e8c82 ;
@@ -1083,7 +1083,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Rubidium"@en .
 
 
-###  http://emmo.info/substance#substance_2ab06c55_4453_4254_8a6e_0447ce1bc76a
+###  https://w3id.org/emmo/chemicalsubstance#substance_2ab06c55_4453_4254_8a6e_0447ce1bc76a
 :substance_2ab06c55_4453_4254_8a6e_0447ce1bc76a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q18002898"@en ;
@@ -1095,7 +1095,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIISulfite"@en .
 
 
-###  http://emmo.info/substance#substance_2aef236e_eaf8_479d_aaa4_a08392b8a90b
+###  https://w3id.org/emmo/chemicalsubstance#substance_2aef236e_eaf8_479d_aaa4_a08392b8a90b
 :substance_2aef236e_eaf8_479d_aaa4_a08392b8a90b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q419686"@en ;
@@ -1108,14 +1108,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIIFluoride"@en .
 
 
-###  http://emmo.info/substance#substance_2b7473ba_9156_489a_880f_3a2f746cd104
+###  https://w3id.org/emmo/chemicalsubstance#substance_2b7473ba_9156_489a_880f_3a2f746cd104
 :substance_2b7473ba_9156_489a_880f_3a2f746cd104 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 skos:altLabel "Mg(TFOB)2"@en ;
                                                 skos:prefLabel "MagnesiumTrifluoromethanesulfonyloxalatoborate"@en .
 
 
-###  http://emmo.info/substance#substance_2b9de1a2_18cc_41ea_81e0_cf576ca56015
+###  https://w3id.org/emmo/chemicalsubstance#substance_2b9de1a2_18cc_41ea_81e0_cf576ca56015
 :substance_2b9de1a2_18cc_41ea_81e0_cf576ca56015 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_de038959_9251_48d1_a141_3684f14d957f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q419729"@en ;
@@ -1128,7 +1128,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BerylliumHydroxide"@en .
 
 
-###  http://emmo.info/substance#substance_2c0d3403_e3d9_4e5d_93ec_625261f74217
+###  https://w3id.org/emmo/chemicalsubstance#substance_2c0d3403_e3d9_4e5d_93ec_625261f74217
 :substance_2c0d3403_e3d9_4e5d_93ec_625261f74217 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_cac14194_2d5f_4fe6_b794_a9319f6d76ee ;
@@ -1141,7 +1141,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Krypton"@en .
 
 
-###  http://emmo.info/substance#substance_2c83627a_1b7e_43d4_a077_77e1aec35af8
+###  https://w3id.org/emmo/chemicalsubstance#substance_2c83627a_1b7e_43d4_a077_77e1aec35af8
 :substance_2c83627a_1b7e_43d4_a077_77e1aec35af8 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q121874"@en ;
@@ -1154,7 +1154,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumIodide"@en .
 
 
-###  http://emmo.info/substance#substance_2c939a73_6363_435a_bbc4_4f6ae02f30d1
+###  https://w3id.org/emmo/chemicalsubstance#substance_2c939a73_6363_435a_bbc4_4f6ae02f30d1
 :substance_2c939a73_6363_435a_bbc4_4f6ae02f30d1 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q27118029"@en ;
@@ -1167,7 +1167,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Tetrafluoroborate"@en .
 
 
-###  http://emmo.info/substance#substance_2c9a9480_4efd_46fe_929a_5e4506ce429b
+###  https://w3id.org/emmo/chemicalsubstance#substance_2c9a9480_4efd_46fe_929a_5e4506ce429b
 :substance_2c9a9480_4efd_46fe_929a_5e4506ce429b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q190227"@en ;
@@ -1180,7 +1180,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumCarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_2d7695d2_c033_4949_b8f6_4984dcfdb46a
+###  https://w3id.org/emmo/chemicalsubstance#substance_2d7695d2_c033_4949_b8f6_4984dcfdb46a
 :substance_2d7695d2_c033_4949_b8f6_4984dcfdb46a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/11552763" ;
@@ -1191,13 +1191,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumTriflate"@en .
 
 
-###  http://emmo.info/substance#substance_2e4767fb_2c1b_43e5_9716_acd3f34b4301
+###  https://w3id.org/emmo/chemicalsubstance#substance_2e4767fb_2c1b_43e5_9716_acd3f34b4301
 :substance_2e4767fb_2c1b_43e5_9716_acd3f34b4301 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "PlatinumOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_2e70735d_8769_4416_948b_ab9e856050b7
+###  https://w3id.org/emmo/chemicalsubstance#substance_2e70735d_8769_4416_948b_ab9e856050b7
 :substance_2e70735d_8769_4416_948b_ab9e856050b7 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q418767"@en ;
@@ -1210,7 +1210,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumAcetate"@en .
 
 
-###  http://emmo.info/substance#substance_2e758ca0_7f2a_446b_b416_e5bb0ec2dae7
+###  https://w3id.org/emmo/chemicalsubstance#substance_2e758ca0_7f2a_446b_b416_e5bb0ec2dae7
 :substance_2e758ca0_7f2a_446b_b416_e5bb0ec2dae7 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q6647971"@en ;
@@ -1223,7 +1223,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumTetrachloroaluminate"@en .
 
 
-###  http://emmo.info/substance#substance_2eaab67b_5117_41a6_b485_2bd53564e44c
+###  https://w3id.org/emmo/chemicalsubstance#substance_2eaab67b_5117_41a6_b485_2bd53564e44c
 :substance_2eaab67b_5117_41a6_b485_2bd53564e44c rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_78400dc0_97b0_4d59_8ea6_30bb703f428c ;
@@ -1237,7 +1237,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Nitrogen"@en .
 
 
-###  http://emmo.info/substance#substance_2ee4c506_526d_4483_bca3_b95585f77d00
+###  https://w3id.org/emmo/chemicalsubstance#substance_2ee4c506_526d_4483_bca3_b95585f77d00
 :substance_2ee4c506_526d_4483_bca3_b95585f77d00 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_878a0e2f_12ba_484e_8197_75e57139d207 ,
                                                                 :substance_961f7671_8708_4ce3_9c7d_79444adba9c0 ;
@@ -1251,7 +1251,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IsopropylAlcohol"@en .
 
 
-###  http://emmo.info/substance#substance_2f1bbf42_2021_453e_baf0_937607b4919e
+###  https://w3id.org/emmo/chemicalsubstance#substance_2f1bbf42_2021_453e_baf0_937607b4919e
 :substance_2f1bbf42_2021_453e_baf0_937607b4919e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q180713"@en ;
@@ -1264,13 +1264,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIIAcetate"@en .
 
 
-###  http://emmo.info/substance#substance_2fc3e95b_6f48_47ea_a366_bcc26336239a
+###  https://w3id.org/emmo/chemicalsubstance#substance_2fc3e95b_6f48_47ea_a366_bcc26336239a
 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ;
                                                 skos:prefLabel "TransitionMetalElementalSubstance"@en .
 
 
-###  http://emmo.info/substance#substance_30078875_6d7b_4c2b_8cae_1c73e6031163
+###  https://w3id.org/emmo/chemicalsubstance#substance_30078875_6d7b_4c2b_8cae_1c73e6031163
 :substance_30078875_6d7b_4c2b_8cae_1c73e6031163 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_878a0e2f_12ba_484e_8197_75e57139d207 ,
                                                                 :substance_961f7671_8708_4ce3_9c7d_79444adba9c0 ;
@@ -1284,7 +1284,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NButanol"@en .
 
 
-###  http://emmo.info/substance#substance_3016a276_0f17_4576_b8fd_200c07d71bfc
+###  https://w3id.org/emmo/chemicalsubstance#substance_3016a276_0f17_4576_b8fd_200c07d71bfc
 :substance_3016a276_0f17_4576_b8fd_200c07d71bfc rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q188543"@en ;
@@ -1297,7 +1297,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumChloride"@en .
 
 
-###  http://emmo.info/substance#substance_3061643c_9dea_4e98_bc1f_6e1a28567c1d
+###  https://w3id.org/emmo/chemicalsubstance#substance_3061643c_9dea_4e98_bc1f_6e1a28567c1d
 :substance_3061643c_9dea_4e98_bc1f_6e1a28567c1d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421071"@en ;
@@ -1310,7 +1310,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIIChloride"@en .
 
 
-###  http://emmo.info/substance#substance_30960f1f_5af5_4700_8df8_428c994b5cb6
+###  https://w3id.org/emmo/chemicalsubstance#substance_30960f1f_5af5_4700_8df8_428c994b5cb6
 :substance_30960f1f_5af5_4700_8df8_428c994b5cb6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q159096"@en ;
@@ -1323,7 +1323,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumIodide"@en .
 
 
-###  http://emmo.info/substance#substance_31d0d139_7b45_4d1e_8603_92cc12da2fad
+###  https://w3id.org/emmo/chemicalsubstance#substance_31d0d139_7b45_4d1e_8603_92cc12da2fad
 :substance_31d0d139_7b45_4d1e_8603_92cc12da2fad rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2802973"@en ;
@@ -1336,7 +1336,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "VinyleneCarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_3210b87b_988f_49f5_99a8_0a20cd42db57
+###  https://w3id.org/emmo/chemicalsubstance#substance_3210b87b_988f_49f5_99a8_0a20cd42db57
 :substance_3210b87b_988f_49f5_99a8_0a20cd42db57 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -1349,7 +1349,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Hexamethylphosphoramide"@en .
 
 
-###  http://emmo.info/substance#substance_323a2e39_d7d5_4802_884a_9aa41a280986
+###  https://w3id.org/emmo/chemicalsubstance#substance_323a2e39_d7d5_4802_884a_9aa41a280986
 :substance_323a2e39_d7d5_4802_884a_9aa41a280986 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_8e5448fc_1916_4afb_9fd9_2489797f6922 ;
@@ -1361,7 +1361,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IronIIIHydroxide"@en .
 
 
-###  http://emmo.info/substance#substance_3286d184_258d_4f80_965b_b9277d57f1b0
+###  https://w3id.org/emmo/chemicalsubstance#substance_3286d184_258d_4f80_965b_b9277d57f1b0
 :substance_3286d184_258d_4f80_965b_b9277d57f1b0 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407189"@en ;
@@ -1373,7 +1373,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Perchlorate"@en .
 
 
-###  http://emmo.info/substance#substance_3297942c_1564_44de_a966_c04fa5da0a4e
+###  https://w3id.org/emmo/chemicalsubstance#substance_3297942c_1564_44de_a966_c04fa5da0a4e
 :substance_3297942c_1564_44de_a966_c04fa5da0a4e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q27292979"@en ;
@@ -1385,7 +1385,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincTetrafluoroborate"@en .
 
 
-###  http://emmo.info/substance#substance_334b7617_34d5_4cb4_9e03_cde9ff19183d
+###  https://w3id.org/emmo/chemicalsubstance#substance_334b7617_34d5_4cb4_9e03_cde9ff19183d
 :substance_334b7617_34d5_4cb4_9e03_cde9ff19183d rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_b978912b_19ef_4d46_8c91_2e3578b12670 ;
@@ -1398,14 +1398,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Bismuth"@en .
 
 
-###  http://emmo.info/substance#substance_3370cbd2_3fb0_47ba_9a20_50124ae6b4cb
+###  https://w3id.org/emmo/chemicalsubstance#substance_3370cbd2_3fb0_47ba_9a20_50124ae6b4cb
 :substance_3370cbd2_3fb0_47ba_9a20_50124ae6b4cb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 skos:altLabel "LiTFOB"@en ;
                                                 skos:prefLabel "LithiumTrifluoromethanesulfonyloxalatoborate"@en .
 
 
-###  http://emmo.info/substance#substance_3421af1a_a9fc_4079_a1a5_37d828f0c94b
+###  https://w3id.org/emmo/chemicalsubstance#substance_3421af1a_a9fc_4079_a1a5_37d828f0c94b
 :substance_3421af1a_a9fc_4079_a1a5_37d828f0c94b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72494142"@en ;
@@ -1417,7 +1417,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIITriflate"@en .
 
 
-###  http://emmo.info/substance#substance_350eaefc_75e1_49d8_b161_01a634607857
+###  https://w3id.org/emmo/chemicalsubstance#substance_350eaefc_75e1_49d8_b161_01a634607857
 :substance_350eaefc_75e1_49d8_b161_01a634607857 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_29fd347b_6a15_4c98_a982_84cf555b0b86 ;
@@ -1431,7 +1431,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PhosphoricAcid"@en .
 
 
-###  http://emmo.info/substance#substance_352ee172_3801_4ccd_89b9_4b80e80ee1e5
+###  https://w3id.org/emmo/chemicalsubstance#substance_352ee172_3801_4ccd_89b9_4b80e80ee1e5
 :substance_352ee172_3801_4ccd_89b9_4b80e80ee1e5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q414440"@en ;
@@ -1444,13 +1444,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumSulfate"@en .
 
 
-###  http://emmo.info/substance#substance_3540fb20_f719_42eb_ad0c_112ffedb7c6d
+###  https://w3id.org/emmo/chemicalsubstance#substance_3540fb20_f719_42eb_ad0c_112ffedb7c6d
 :substance_3540fb20_f719_42eb_ad0c_112ffedb7c6d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "CadmiumOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_35dec16f_58dc_41be_9878_a3c29fd5cdd2
+###  https://w3id.org/emmo/chemicalsubstance#substance_35dec16f_58dc_41be_9878_a3c29fd5cdd2
 :substance_35dec16f_58dc_41be_9878_a3c29fd5cdd2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q417109"@en ;
@@ -1463,7 +1463,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumSulfite"@en .
 
 
-###  http://emmo.info/substance#substance_3604e3b6_2e54_41b2_b204_f52a427b990a
+###  https://w3id.org/emmo/chemicalsubstance#substance_3604e3b6_2e54_41b2_b204_f52a427b990a
 :substance_3604e3b6_2e54_41b2_b204_f52a427b990a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407796"@en ;
@@ -1475,7 +1475,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PentanoicAcid"@en .
 
 
-###  http://emmo.info/substance#substance_361464d9_c796_413f_b261_0a321d68f04a
+###  https://w3id.org/emmo/chemicalsubstance#substance_361464d9_c796_413f_b261_0a321d68f04a
 :substance_361464d9_c796_413f_b261_0a321d68f04a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411859"@en ;
@@ -1488,7 +1488,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumChloride"@en .
 
 
-###  http://emmo.info/substance#substance_371fbcaa_d782_4f4c_86e3_58e1a58d3bea
+###  https://w3id.org/emmo/chemicalsubstance#substance_371fbcaa_d782_4f4c_86e3_58e1a58d3bea
 :substance_371fbcaa_d782_4f4c_86e3_58e1a58d3bea rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a9218f8f_2e80_497e_b968_b4947cf21802 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q36200"@en ;
@@ -1501,7 +1501,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZirconiumIVOxide"@en .
 
 
-###  http://emmo.info/substance#substance_37c4342f_3c3f_47d3_97f0_761c8c877933
+###  https://w3id.org/emmo/chemicalsubstance#substance_37c4342f_3c3f_47d3_97f0_761c8c877933
 :substance_37c4342f_3c3f_47d3_97f0_761c8c877933 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a9a6507f_9c61_44d3_bd86_f1ebf763e150 ;
@@ -1515,7 +1515,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Germanium"@en .
 
 
-###  http://emmo.info/substance#substance_38178633_83fb_42ea_81a2_cd23e9db9b04
+###  https://w3id.org/emmo/chemicalsubstance#substance_38178633_83fb_42ea_81a2_cd23e9db9b04
 :substance_38178633_83fb_42ea_81a2_cd23e9db9b04 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_cac14194_2d5f_4fe6_b794_a9319f6d76ee ;
@@ -1528,7 +1528,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Argon"@en .
 
 
-###  http://emmo.info/substance#substance_383f6ea4_344d_4f3f_ae04_4c5005e9c8fd
+###  https://w3id.org/emmo/chemicalsubstance#substance_383f6ea4_344d_4f3f_ae04_4c5005e9c8fd
 :substance_383f6ea4_344d_4f3f_ae04_4c5005e9c8fd rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_52da9471_9979_44b0_a415_63c72110fd43 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q419170"@en ;
@@ -1538,7 +1538,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IronIIIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_385410f6_0c03_4942_b35f_52a664b5622c
+###  https://w3id.org/emmo/chemicalsubstance#substance_385410f6_0c03_4942_b35f_52a664b5622c
 :substance_385410f6_0c03_4942_b35f_52a664b5622c rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421458"@en ;
@@ -1552,14 +1552,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TetraethylOrthosilicate"@en .
 
 
-###  http://emmo.info/substance#substance_3896eebe_80a4_441a_bd73_52be793482a6
+###  https://w3id.org/emmo/chemicalsubstance#substance_3896eebe_80a4_441a_bd73_52be793482a6
 :substance_3896eebe_80a4_441a_bd73_52be793482a6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 skos:altLabel "Sr(PF6)2"@en ;
                                                 skos:prefLabel "StrontiumHexafluorophosphate"@en .
 
 
-###  http://emmo.info/substance#substance_3899a9c9_9b34_443e_8ce6_0257589bb38a
+###  https://w3id.org/emmo/chemicalsubstance#substance_3899a9c9_9b34_443e_8ce6_0257589bb38a
 :substance_3899a9c9_9b34_443e_8ce6_0257589bb38a rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1079788" ;
@@ -1575,7 +1575,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
  ] .
 
 
-###  http://emmo.info/substance#substance_3ac62305_acd6_4312_9e31_4f824bd2530d
+###  https://w3id.org/emmo/chemicalsubstance#substance_3ac62305_acd6_4312_9e31_4f824bd2530d
 :substance_3ac62305_acd6_4312_9e31_4f824bd2530d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q121086245"@en ;
@@ -1584,7 +1584,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumNickelManganeseCobaltOxide"@en .
 
 
-###  http://emmo.info/substance#substance_3b02df00_df48_4e41_aea1_d291681dcf0e
+###  https://w3id.org/emmo/chemicalsubstance#substance_3b02df00_df48_4e41_aea1_d291681dcf0e
 :substance_3b02df00_df48_4e41_aea1_d291681dcf0e rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_b978912b_19ef_4d46_8c91_2e3578b12670 ;
@@ -1597,7 +1597,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Polonium"@en .
 
 
-###  http://emmo.info/substance#substance_3c8fb431_7d9d_4a89_a494_708df34f44d3
+###  https://w3id.org/emmo/chemicalsubstance#substance_3c8fb431_7d9d_4a89_a494_708df34f44d3
 :substance_3c8fb431_7d9d_4a89_a494_708df34f44d3 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q413421"@en ;
@@ -1610,7 +1610,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Dimethylsulfate"@en .
 
 
-###  http://emmo.info/substance#substance_3d3ca8c8_4ea0_43b8_b496_aca78a0d1584
+###  https://w3id.org/emmo/chemicalsubstance#substance_3d3ca8c8_4ea0_43b8_b496_aca78a0d1584
 :substance_3d3ca8c8_4ea0_43b8_b496_aca78a0d1584 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/16700902" ;
@@ -1621,7 +1621,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIIPhosphate"@en .
 
 
-###  http://emmo.info/substance#substance_3d6c473f_fdfb_4f8a_922e_215d18691e21
+###  https://w3id.org/emmo/chemicalsubstance#substance_3d6c473f_fdfb_4f8a_922e_215d18691e21
 :substance_3d6c473f_fdfb_4f8a_922e_215d18691e21 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/83717" ;
@@ -1632,7 +1632,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIIIodide"@en .
 
 
-###  http://emmo.info/substance#substance_3dfd47ff_ed4b_4e83_85a0_02917b79fef9
+###  https://w3id.org/emmo/chemicalsubstance#substance_3dfd47ff_ed4b_4e83_85a0_02917b79fef9
 :substance_3dfd47ff_ed4b_4e83_85a0_02917b79fef9 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_8e5448fc_1916_4afb_9fd9_2489797f6922 ;
@@ -1646,7 +1646,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Ammonia"@en .
 
 
-###  http://emmo.info/substance#substance_3eaad9be_eae9_4735_b03a_1b07f9f79805
+###  https://w3id.org/emmo/chemicalsubstance#substance_3eaad9be_eae9_4735_b03a_1b07f9f79805
 :substance_3eaad9be_eae9_4735_b03a_1b07f9f79805 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411207"@en ;
@@ -1659,7 +1659,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIIodide"@en .
 
 
-###  http://emmo.info/substance#substance_3f5d5e9c_adb6_4fbb_88a5_1d5472e2c99f
+###  https://w3id.org/emmo/chemicalsubstance#substance_3f5d5e9c_adb6_4fbb_88a5_1d5472e2c99f
 :substance_3f5d5e9c_adb6_4fbb_88a5_1d5472e2c99f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4493207"@en ;
@@ -1672,7 +1672,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIIFluoride"@en .
 
 
-###  http://emmo.info/substance#substance_3fd0b901_88fa_47e2_9d99_7db13cd02c9f
+###  https://w3id.org/emmo/chemicalsubstance#substance_3fd0b901_88fa_47e2_9d99_7db13cd02c9f
 :substance_3fd0b901_88fa_47e2_9d99_7db13cd02c9f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2754907"@en ;
@@ -1685,7 +1685,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumTetrafluoroborate"@en .
 
 
-###  http://emmo.info/substance#substance_40bdf780_394e_49e8_9a46_c88320c9d734
+###  https://w3id.org/emmo/chemicalsubstance#substance_40bdf780_394e_49e8_9a46_c88320c9d734
 :substance_40bdf780_394e_49e8_9a46_c88320c9d734 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q899410"@en ;
@@ -1698,7 +1698,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumSulfite"@en .
 
 
-###  http://emmo.info/substance#substance_4112b3b8_69fa_4f20_9f99_f572f57ab66f
+###  https://w3id.org/emmo/chemicalsubstance#substance_4112b3b8_69fa_4f20_9f99_f572f57ab66f
 :substance_4112b3b8_69fa_4f20_9f99_f572f57ab66f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q424906"@en ;
@@ -1710,7 +1710,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "GlycericAcid"@en .
 
 
-###  http://emmo.info/substance#substance_4126ee09_b9c6_4694_bf33_0d8970e05f72
+###  https://w3id.org/emmo/chemicalsubstance#substance_4126ee09_b9c6_4694_bf33_0d8970e05f72
 :substance_4126ee09_b9c6_4694_bf33_0d8970e05f72 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc9ba950_96c1_4ac2_a0e2_1c4f7f001b1d ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407879"@en ;
@@ -1723,7 +1723,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_41379755_2818_4dea_b3d3_15ac755fb751
+###  https://w3id.org/emmo/chemicalsubstance#substance_41379755_2818_4dea_b3d3_15ac755fb751
 :substance_41379755_2818_4dea_b3d3_15ac755fb751 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q414860"@en ;
@@ -1736,7 +1736,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIINitrate"@en .
 
 
-###  http://emmo.info/substance#substance_413d32e9_2ec2_474a_9ddb_48277920ba21
+###  https://w3id.org/emmo/chemicalsubstance#substance_413d32e9_2ec2_474a_9ddb_48277920ba21
 :substance_413d32e9_2ec2_474a_9ddb_48277920ba21 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q27266022"@en ;
@@ -1749,13 +1749,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincPerchlorate"@en .
 
 
-###  http://emmo.info/substance#substance_4154e6b6_8e3c_4173_91aa_e8ba403bde85
+###  https://w3id.org/emmo/chemicalsubstance#substance_4154e6b6_8e3c_4173_91aa_e8ba403bde85
 :substance_4154e6b6_8e3c_4173_91aa_e8ba403bde85 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_015116fe_94ca_4be5_9d14_9d9457a47a72 ;
                                                 skos:prefLabel "IronSalt"@en .
 
 
-###  http://emmo.info/substance#substance_41bcd359_dc00_45f4_8746_d40c91e64f94
+###  https://w3id.org/emmo/chemicalsubstance#substance_41bcd359_dc00_45f4_8746_d40c91e64f94
 :substance_41bcd359_dc00_45f4_8746_d40c91e64f94 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q423852"@en ;
@@ -1768,14 +1768,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumPhosphate"@en .
 
 
-###  http://emmo.info/substance#substance_41cd4dfd_2288_48b2_a1e3_d13821c21a1e
+###  https://w3id.org/emmo/chemicalsubstance#substance_41cd4dfd_2288_48b2_a1e3_d13821c21a1e
 :substance_41cd4dfd_2288_48b2_a1e3_d13821c21a1e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 skos:altLabel "Sr(FSI)2"@en ;
                                                 skos:prefLabel "StrontiumBisfluorosulfonylimide"@en .
 
 
-###  http://emmo.info/substance#substance_4216bdc4_ef30_43e6_bd44_47f78761939e
+###  https://w3id.org/emmo/chemicalsubstance#substance_4216bdc4_ef30_43e6_bd44_47f78761939e
 :substance_4216bdc4_ef30_43e6_bd44_47f78761939e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q18211720"@en ;
@@ -1788,7 +1788,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumNitrite"@en .
 
 
-###  http://emmo.info/substance#substance_4295c63e_3024_4e69_8da5_102861bebac1
+###  https://w3id.org/emmo/chemicalsubstance#substance_4295c63e_3024_4e69_8da5_102861bebac1
 :substance_4295c63e_3024_4e69_8da5_102861bebac1 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dc68514f_b592_4e1b_a00f_fbb29f2fafbd ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q412967"@en ;
@@ -1800,7 +1800,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Nafion"@en .
 
 
-###  http://emmo.info/substance#substance_4310c690_9810_4a95_8d62_7e78e0b84437
+###  https://w3id.org/emmo/chemicalsubstance#substance_4310c690_9810_4a95_8d62_7e78e0b84437
 :substance_4310c690_9810_4a95_8d62_7e78e0b84437 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421198"@en ;
@@ -1813,7 +1813,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIIAcetate"@en .
 
 
-###  http://emmo.info/substance#substance_43aef3e7_12aa_44b2_9d0f_973e634bfbe0
+###  https://w3id.org/emmo/chemicalsubstance#substance_43aef3e7_12aa_44b2_9d0f_973e634bfbe0
 :substance_43aef3e7_12aa_44b2_9d0f_973e634bfbe0 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_78400dc0_97b0_4d59_8ea6_30bb703f428c ;
@@ -1827,14 +1827,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Chlorine"@en .
 
 
-###  http://emmo.info/substance#substance_43ec3168_0f1a_44aa_99ad_716fcc48bbcb
+###  https://w3id.org/emmo/chemicalsubstance#substance_43ec3168_0f1a_44aa_99ad_716fcc48bbcb
 :substance_43ec3168_0f1a_44aa_99ad_716fcc48bbcb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 skos:altLabel "Mg(FSI)2"@en ;
                                                 skos:prefLabel "MagnesiumBisfluorosulfonylimide"@en .
 
 
-###  http://emmo.info/substance#substance_44a9a4e3_488e_4687_aca7_b045e12147f7
+###  https://w3id.org/emmo/chemicalsubstance#substance_44a9a4e3_488e_4687_aca7_b045e12147f7
 :substance_44a9a4e3_488e_4687_aca7_b045e12147f7 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_155e894b_66de_4cda_9dbe_adbeca7d8102 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204980"@en ;
@@ -1847,7 +1847,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TinIIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_4525c1ee_1d0c_4a17_9fa8_24c19c690db6
+###  https://w3id.org/emmo/chemicalsubstance#substance_4525c1ee_1d0c_4a17_9fa8_24c19c690db6
 :substance_4525c1ee_1d0c_4a17_9fa8_24c19c690db6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q11129394"@en ;
@@ -1860,7 +1860,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumChlorate"@en .
 
 
-###  http://emmo.info/substance#substance_465f2569_2bb8_4360_a2cb_480017390074
+###  https://w3id.org/emmo/chemicalsubstance#substance_465f2569_2bb8_4360_a2cb_480017390074
 :substance_465f2569_2bb8_4360_a2cb_480017390074 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q425274"@en ;
@@ -1873,7 +1873,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIINitrate"@en .
 
 
-###  http://emmo.info/substance#substance_469e5dc9_7b3e_4e72_8fd5_fe2e8386862d
+###  https://w3id.org/emmo/chemicalsubstance#substance_469e5dc9_7b3e_4e72_8fd5_fe2e8386862d
 :substance_469e5dc9_7b3e_4e72_8fd5_fe2e8386862d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/10130077" ;
@@ -1884,7 +1884,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIINitrite"@en .
 
 
-###  http://emmo.info/substance#substance_46e9f253_40cb_4b48_b8d0_0b976ea4e156
+###  https://w3id.org/emmo/chemicalsubstance#substance_46e9f253_40cb_4b48_b8d0_0b976ea4e156
 :substance_46e9f253_40cb_4b48_b8d0_0b976ea4e156 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -1898,7 +1898,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PropyleneCarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_46eb3e23_0d77_4e1e_9c3c_48a47f8d022c
+###  https://w3id.org/emmo/chemicalsubstance#substance_46eb3e23_0d77_4e1e_9c3c_48a47f8d022c
 :substance_46eb3e23_0d77_4e1e_9c3c_48a47f8d022c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q426354"@en ;
@@ -1910,13 +1910,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumPhosphate"@en .
 
 
-###  http://emmo.info/substance#substance_4744a12c_ca28_46b4_9e59_43c1cc15b536
+###  https://w3id.org/emmo/chemicalsubstance#substance_4744a12c_ca28_46b4_9e59_43c1cc15b536
 :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_6c490298_2ce8_41e1_ac37_4b44faff2d44 ;
                                                 skos:prefLabel "LithiumSaltCompound"@en .
 
 
-###  http://emmo.info/substance#substance_47766d88_0ded_4f5c_87f9_f810fe5ce02b
+###  https://w3id.org/emmo/chemicalsubstance#substance_47766d88_0ded_4f5c_87f9_f810fe5ce02b
 :substance_47766d88_0ded_4f5c_87f9_f810fe5ce02b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q8010655"@en ;
@@ -1929,7 +1929,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumTetrachloroaluminate"@en .
 
 
-###  http://emmo.info/substance#substance_4780139a_615a_4a28_a7be_bbbb28f3ec68
+###  https://w3id.org/emmo/chemicalsubstance#substance_4780139a_615a_4a28_a7be_bbbb28f3ec68
 :substance_4780139a_615a_4a28_a7be_bbbb28f3ec68 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q177836"@en ;
@@ -1942,7 +1942,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumNitrate"@en .
 
 
-###  http://emmo.info/substance#substance_4796594d_8de9_482d_9644_7ee776941dc2
+###  https://w3id.org/emmo/chemicalsubstance#substance_4796594d_8de9_482d_9644_7ee776941dc2
 :substance_4796594d_8de9_482d_9644_7ee776941dc2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a639df56_1fb2_47f3_8069_c929b5a84b86 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q425350"@en ;
@@ -1955,7 +1955,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "VanadiumIIIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_47a21fb6_2158_4f41_8f74_5b873d5eae53
+###  https://w3id.org/emmo/chemicalsubstance#substance_47a21fb6_2158_4f41_8f74_5b873d5eae53
 :substance_47a21fb6_2158_4f41_8f74_5b873d5eae53 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q899422"@en ;
@@ -1968,7 +1968,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIIAcetate"@en .
 
 
-###  http://emmo.info/substance#substance_480a4c29_fa1b_4e14_b5e0_a0b82d73df57
+###  https://w3id.org/emmo/chemicalsubstance#substance_480a4c29_fa1b_4e14_b5e0_a0b82d73df57
 :substance_480a4c29_fa1b_4e14_b5e0_a0b82d73df57 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72487598"@en ;
@@ -1980,7 +1980,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumDifluorooxalatoborate"@en .
 
 
-###  http://emmo.info/substance#substance_48108f36_d856_46d4_b293_e174aeff9970
+###  https://w3id.org/emmo/chemicalsubstance#substance_48108f36_d856_46d4_b293_e174aeff9970
 :substance_48108f36_d856_46d4_b293_e174aeff9970 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/substance/482775751" ;
@@ -1988,7 +1988,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIITriflate"@en .
 
 
-###  http://emmo.info/substance#substance_48831514_d92f_4c67_8065_98df6f4d11cb
+###  https://w3id.org/emmo/chemicalsubstance#substance_48831514_d92f_4c67_8065_98df6f4d11cb
 :substance_48831514_d92f_4c67_8065_98df6f4d11cb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q211737"@en ;
@@ -2001,7 +2001,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumSulfate"@en .
 
 
-###  http://emmo.info/substance#substance_4a00b074_17b5_417c_996b_d0ac47041030
+###  https://w3id.org/emmo/chemicalsubstance#substance_4a00b074_17b5_417c_996b_d0ac47041030
 :substance_4a00b074_17b5_417c_996b_d0ac47041030 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q194322"@en ;
@@ -2013,7 +2013,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TartaricAcid"@en .
 
 
-###  http://emmo.info/substance#substance_4a72632d_2168_4f66_8cd7_e764ea7909d6
+###  https://w3id.org/emmo/chemicalsubstance#substance_4a72632d_2168_4f66_8cd7_e764ea7909d6
 :substance_4a72632d_2168_4f66_8cd7_e764ea7909d6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421250"@en ;
@@ -2026,7 +2026,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIIIodide"@en .
 
 
-###  http://emmo.info/substance#substance_4a839093_754f_4ba2_920b_0681697f32b3
+###  https://w3id.org/emmo/chemicalsubstance#substance_4a839093_754f_4ba2_920b_0681697f32b3
 :substance_4a839093_754f_4ba2_920b_0681697f32b3 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72502023"@en ;
@@ -2038,13 +2038,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumTriflate"@en .
 
 
-###  http://emmo.info/substance#substance_4ad18bbe_6478_4009_8f80_b669a6ae3f7a
+###  https://w3id.org/emmo/chemicalsubstance#substance_4ad18bbe_6478_4009_8f80_b669a6ae3f7a
 :substance_4ad18bbe_6478_4009_8f80_b669a6ae3f7a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "IridiumOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_4b3e8f9e_9857_4bc3_8e17_aa75757d9860
+###  https://w3id.org/emmo/chemicalsubstance#substance_4b3e8f9e_9857_4bc3_8e17_aa75757d9860
 :substance_4b3e8f9e_9857_4bc3_8e17_aa75757d9860 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q420146"@en ;
@@ -2057,7 +2057,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumNitrate"@en .
 
 
-###  http://emmo.info/substance#substance_4c01eadc_81a0_4ad7_a72f_4d5f72f60f04
+###  https://w3id.org/emmo/chemicalsubstance#substance_4c01eadc_81a0_4ad7_a72f_4d5f72f60f04
 :substance_4c01eadc_81a0_4ad7_a72f_4d5f72f60f04 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/23677815" ;
@@ -2068,7 +2068,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumBisoxalatoborate"@en .
 
 
-###  http://emmo.info/substance#substance_4c6265b5_d9e4_4493_b1e8_ae35f463ceeb
+###  https://w3id.org/emmo/chemicalsubstance#substance_4c6265b5_d9e4_4493_b1e8_ae35f463ceeb
 :substance_4c6265b5_d9e4_4493_b1e8_ae35f463ceeb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q20107470"@en ;
@@ -2080,7 +2080,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumPerchlorate"@en .
 
 
-###  http://emmo.info/substance#substance_4c62d334_a124_40b3_9fd1_fe713d01a6af
+###  https://w3id.org/emmo/chemicalsubstance#substance_4c62d334_a124_40b3_9fd1_fe713d01a6af
 :substance_4c62d334_a124_40b3_9fd1_fe713d01a6af rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q415891"@en ;
@@ -2093,13 +2093,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumCobaltOxide"@en .
 
 
-###  http://emmo.info/substance#substance_4ca80d73_ea14_4a81_9df1_8a16ecbfd041
+###  https://w3id.org/emmo/chemicalsubstance#substance_4ca80d73_ea14_4a81_9df1_8a16ecbfd041
 :substance_4ca80d73_ea14_4a81_9df1_8a16ecbfd041 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "RutheniumOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_4cb44b89_42ca_481e_b883_ab9cf6621862
+###  https://w3id.org/emmo/chemicalsubstance#substance_4cb44b89_42ca_481e_b883_ab9cf6621862
 :substance_4cb44b89_42ca_481e_b883_ab9cf6621862 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2314"@en ;
@@ -2112,14 +2112,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumChloride"@en .
 
 
-###  http://emmo.info/substance#substance_4d6845ce_47c8_4c7d_b275_1d4494a0799b
+###  https://w3id.org/emmo/chemicalsubstance#substance_4d6845ce_47c8_4c7d_b275_1d4494a0799b
 :substance_4d6845ce_47c8_4c7d_b275_1d4494a0799b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 skos:altLabel "Ba(TFOB)2"@en ;
                                                 skos:prefLabel "BariumTrifluoromethanesulfonyloxalatoborate"@en .
 
 
-###  http://emmo.info/substance#substance_4de6c4d5_0d8d_418c_b3f0_c780f000cd55
+###  https://w3id.org/emmo/chemicalsubstance#substance_4de6c4d5_0d8d_418c_b3f0_c780f000cd55
 :substance_4de6c4d5_0d8d_418c_b3f0_c780f000cd55 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409501"@en ;
@@ -2132,7 +2132,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumPhosphate"@en .
 
 
-###  http://emmo.info/substance#substance_4e27d4ae_cb93_475a_8a97_121fc8e0248e
+###  https://w3id.org/emmo/chemicalsubstance#substance_4e27d4ae_cb93_475a_8a97_121fc8e0248e
 :substance_4e27d4ae_cb93_475a_8a97_121fc8e0248e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q339940"@en ;
@@ -2145,7 +2145,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumAcetate"@en .
 
 
-###  http://emmo.info/substance#substance_4e2e3adb_47cc_44d8_a3c3_28257dffcb28
+###  https://w3id.org/emmo/chemicalsubstance#substance_4e2e3adb_47cc_44d8_a3c3_28257dffcb28
 :substance_4e2e3adb_47cc_44d8_a3c3_28257dffcb28 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q415543"@en ;
@@ -2158,7 +2158,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumSulfite"@en .
 
 
-###  http://emmo.info/substance#substance_4e5582a6_caec_4917_acad_6f472cd7d831
+###  https://w3id.org/emmo/chemicalsubstance#substance_4e5582a6_caec_4917_acad_6f472cd7d831
 :substance_4e5582a6_caec_4917_acad_6f472cd7d831 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_78400dc0_97b0_4d59_8ea6_30bb703f428c ;
@@ -2172,7 +2172,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Carbon"@en .
 
 
-###  http://emmo.info/substance#substance_4ebbe70b_3bba_4b8c_90fc_684017abe192
+###  https://w3id.org/emmo/chemicalsubstance#substance_4ebbe70b_3bba_4b8c_90fc_684017abe192
 :substance_4ebbe70b_3bba_4b8c_90fc_684017abe192 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q417847"@en ;
@@ -2185,7 +2185,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SuccinicAnhydride"@en .
 
 
-###  http://emmo.info/substance#substance_4ebc1929_2acd_4afb_8a13_6b2f70e2956c
+###  https://w3id.org/emmo/chemicalsubstance#substance_4ebc1929_2acd_4afb_8a13_6b2f70e2956c
 :substance_4ebc1929_2acd_4afb_8a13_6b2f70e2956c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q410107"@en ;
@@ -2199,7 +2199,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Cumene"@en .
 
 
-###  http://emmo.info/substance#substance_4ec21ff2_f0f3_470f_8855_05ba6a074ecf
+###  https://w3id.org/emmo/chemicalsubstance#substance_4ec21ff2_f0f3_470f_8855_05ba6a074ecf
 :substance_4ec21ff2_f0f3_470f_8855_05ba6a074ecf rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q408491"@en ;
@@ -2212,7 +2212,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumPerchlorate"@en .
 
 
-###  http://emmo.info/substance#substance_4ed2fb2e_2e73_43c1_bc98_4d0ee34f859e
+###  https://w3id.org/emmo/chemicalsubstance#substance_4ed2fb2e_2e73_43c1_bc98_4d0ee34f859e
 :substance_4ed2fb2e_2e73_43c1_bc98_4d0ee34f859e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/20073715" ;
@@ -2223,7 +2223,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIIHexafluorophosphate"@en .
 
 
-###  http://emmo.info/substance#substance_505b0b88_e622_43e7_bf5e_d04c0b540ccb
+###  https://w3id.org/emmo/chemicalsubstance#substance_505b0b88_e622_43e7_bf5e_d04c0b540ccb
 :substance_505b0b88_e622_43e7_bf5e_d04c0b540ccb rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_78400dc0_97b0_4d59_8ea6_30bb703f428c ;
@@ -2237,7 +2237,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Fluorine"@en .
 
 
-###  http://emmo.info/substance#substance_5088ad54_b37d_4ee1_a086_d6c17e644f9a
+###  https://w3id.org/emmo/chemicalsubstance#substance_5088ad54_b37d_4ee1_a086_d6c17e644f9a
 :substance_5088ad54_b37d_4ee1_a086_d6c17e644f9a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b8c65e71_05de_4f07_acd8_a16938b550fd ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411221"@en ;
@@ -2250,7 +2250,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_508e6e27_16a6_40f4_930c_d6c793721181
+###  https://w3id.org/emmo/chemicalsubstance#substance_508e6e27_16a6_40f4_930c_d6c793721181
 :substance_508e6e27_16a6_40f4_930c_d6c793721181 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q413374"@en ;
@@ -2263,7 +2263,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumFluoride"@en .
 
 
-###  http://emmo.info/substance#substance_513a92b2_26b5_420d_8cf9_922869bbec61
+###  https://w3id.org/emmo/chemicalsubstance#substance_513a92b2_26b5_420d_8cf9_922869bbec61
 :substance_513a92b2_26b5_420d_8cf9_922869bbec61 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -2276,7 +2276,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Hafnium"@en .
 
 
-###  http://emmo.info/substance#substance_51e414c6_e619_446c_898a_dac0f4855584
+###  https://w3id.org/emmo/chemicalsubstance#substance_51e414c6_e619_446c_898a_dac0f4855584
 :substance_51e414c6_e619_446c_898a_dac0f4855584 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q59714"@en ;
@@ -2289,7 +2289,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincPhosphate"@en .
 
 
-###  http://emmo.info/substance#substance_5263c4d3_8759_48a1_b35e_5abf7a1f0454
+###  https://w3id.org/emmo/chemicalsubstance#substance_5263c4d3_8759_48a1_b35e_5abf7a1f0454
 :substance_5263c4d3_8759_48a1_b35e_5abf7a1f0454 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411752"@en ;
@@ -2302,7 +2302,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumFluoride"@en .
 
 
-###  http://emmo.info/substance#substance_527fbfa6_7a48_4f6e_8442_38f2590a51bb
+###  https://w3id.org/emmo/chemicalsubstance#substance_527fbfa6_7a48_4f6e_8442_38f2590a51bb
 :substance_527fbfa6_7a48_4f6e_8442_38f2590a51bb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409739"@en ;
@@ -2315,7 +2315,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumBromide"@en .
 
 
-###  http://emmo.info/substance#substance_52c1076c_9349_44f7_8067_4de36bd49e10
+###  https://w3id.org/emmo/chemicalsubstance#substance_52c1076c_9349_44f7_8067_4de36bd49e10
 :substance_52c1076c_9349_44f7_8067_4de36bd49e10 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q408925"@en ;
@@ -2327,13 +2327,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "HydrazoicAcid"@en .
 
 
-###  http://emmo.info/substance#substance_52da9471_9979_44b0_a415_63c72110fd43
+###  https://w3id.org/emmo/chemicalsubstance#substance_52da9471_9979_44b0_a415_63c72110fd43
 :substance_52da9471_9979_44b0_a415_63c72110fd43 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "IronOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_53682797_c388_4407_9410_1fa6a41fa1da
+###  https://w3id.org/emmo/chemicalsubstance#substance_53682797_c388_4407_9410_1fa6a41fa1da
 :substance_53682797_c388_4407_9410_1fa6a41fa1da rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q417992"@en ;
@@ -2346,7 +2346,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumIodide"@en .
 
 
-###  http://emmo.info/substance#substance_53c372d6_b1fa_4e53_93b3_0904c0580d28
+###  https://w3id.org/emmo/chemicalsubstance#substance_53c372d6_b1fa_4e53_93b3_0904c0580d28
 :substance_53c372d6_b1fa_4e53_93b3_0904c0580d28 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421465"@en ;
@@ -2359,7 +2359,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumIodide"@en .
 
 
-###  http://emmo.info/substance#substance_5414a9d0_6c2e_4d21_bfad_9a19fc8f62f9
+###  https://w3id.org/emmo/chemicalsubstance#substance_5414a9d0_6c2e_4d21_bfad_9a19fc8f62f9
 :substance_5414a9d0_6c2e_4d21_bfad_9a19fc8f62f9 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2336041"@en ;
@@ -2372,7 +2372,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumSulfite"@en .
 
 
-###  http://emmo.info/substance#substance_54f744b3_1d02_4571_a303_a2a7dd8f0446
+###  https://w3id.org/emmo/chemicalsubstance#substance_54f744b3_1d02_4571_a303_a2a7dd8f0446
 :substance_54f744b3_1d02_4571_a303_a2a7dd8f0446 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q413982"@en ;
@@ -2385,7 +2385,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumBromide"@en .
 
 
-###  http://emmo.info/substance#substance_55080032_1536_4cf7_a4a6_7784422720f5
+###  https://w3id.org/emmo/chemicalsubstance#substance_55080032_1536_4cf7_a4a6_7784422720f5
 :substance_55080032_1536_4cf7_a4a6_7784422720f5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q6135415"@en ;
@@ -2397,21 +2397,21 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIISulfite"@en .
 
 
-###  http://emmo.info/substance#substance_55b09b6b_c8cd_410c_8971_b2bd86e0c905
+###  https://w3id.org/emmo/chemicalsubstance#substance_55b09b6b_c8cd_410c_8971_b2bd86e0c905
 :substance_55b09b6b_c8cd_410c_8971_b2bd86e0c905 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 skos:altLabel "Ca(DFOB)2"@en ;
                                                 skos:prefLabel "CalciumDifluorooxalatoborate"@en .
 
 
-###  http://emmo.info/substance#substance_55d2a257_feb3_4af1_bf8d_4b53bb73610c
+###  https://w3id.org/emmo/chemicalsubstance#substance_55d2a257_feb3_4af1_bf8d_4b53bb73610c
 :substance_55d2a257_feb3_4af1_bf8d_4b53bb73610c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 skos:altLabel "Ba(BOP)2"@en ;
                                                 skos:prefLabel "BariumBisoxalatophosphate"@en .
 
 
-###  http://emmo.info/substance#substance_55f13456_b4b6_4cf9_998c_8c439b249b3f
+###  https://w3id.org/emmo/chemicalsubstance#substance_55f13456_b4b6_4cf9_998c_8c439b249b3f
 :substance_55f13456_b4b6_4cf9_998c_8c439b249b3f rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -2424,7 +2424,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Zirconium"@en .
 
 
-###  http://emmo.info/substance#substance_564edbfa_af96_41c5_8fd5_7f22b1ca658d
+###  https://w3id.org/emmo/chemicalsubstance#substance_564edbfa_af96_41c5_8fd5_7f22b1ca658d
 :substance_564edbfa_af96_41c5_8fd5_7f22b1ca658d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q27274769"@en ;
@@ -2437,7 +2437,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIIAcetate"@en .
 
 
-###  http://emmo.info/substance#substance_56639835_9f0b_493f_a38c_268185ef4947
+###  https://w3id.org/emmo/chemicalsubstance#substance_56639835_9f0b_493f_a38c_268185ef4947
 :substance_56639835_9f0b_493f_a38c_268185ef4947 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4ca80d73_ea14_4a81_9df1_8a16ecbfd041 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q416759"@en ;
@@ -2450,7 +2450,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "RutheniumVIIIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_56a8e7ef_29da_46d2_92e4_81c38ec39b4b
+###  https://w3id.org/emmo/chemicalsubstance#substance_56a8e7ef_29da_46d2_92e4_81c38ec39b4b
 :substance_56a8e7ef_29da_46d2_92e4_81c38ec39b4b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409251"@en ;
@@ -2463,7 +2463,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumAcetate"@en .
 
 
-###  http://emmo.info/substance#substance_56c59d5b_ace2_4b5a_9144_fc97f93f9a93
+###  https://w3id.org/emmo/chemicalsubstance#substance_56c59d5b_ace2_4b5a_9144_fc97f93f9a93
 :substance_56c59d5b_ace2_4b5a_9144_fc97f93f9a93 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_001ca83b_5372_4d77_a836_4d48074b7e63 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2985790"@en ;
@@ -2476,7 +2476,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TitaniumIIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_56cdced5_3773_4839_9269_df2d13ea9224
+###  https://w3id.org/emmo/chemicalsubstance#substance_56cdced5_3773_4839_9269_df2d13ea9224
 :substance_56cdced5_3773_4839_9269_df2d13ea9224 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0dcf209c_6455_4305_9714_fec548742c6a ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421063"@en ;
@@ -2489,7 +2489,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PalladiumOxide"@en .
 
 
-###  http://emmo.info/substance#substance_57015be9_f515_4e00_b914_e8130d596bcb
+###  https://w3id.org/emmo/chemicalsubstance#substance_57015be9_f515_4e00_b914_e8130d596bcb
 :substance_57015be9_f515_4e00_b914_e8130d596bcb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/102195115" ;
@@ -2499,7 +2499,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TDI"@en .
 
 
-###  http://emmo.info/substance#substance_57339d90_0553_4a96_8da9_ff6c3684e226
+###  https://w3id.org/emmo/chemicalsubstance#substance_57339d90_0553_4a96_8da9_ff6c3684e226
 :substance_57339d90_0553_4a96_8da9_ff6c3684e226 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421145"@en ;
@@ -2513,7 +2513,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "EthyleneCarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_573a02c5_da67_438f_9056_f66caa1febaf
+###  https://w3id.org/emmo/chemicalsubstance#substance_573a02c5_da67_438f_9056_f66caa1febaf
 :substance_573a02c5_da67_438f_9056_f66caa1febaf rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Nickel(II)_chloride"@en ;
@@ -2526,7 +2526,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIIChloride"@en .
 
 
-###  http://emmo.info/substance#substance_573ba7a1_f6a6_427d_99de_8e80fe406a67
+###  https://w3id.org/emmo/chemicalsubstance#substance_573ba7a1_f6a6_427d_99de_8e80fe406a67
 :substance_573ba7a1_f6a6_427d_99de_8e80fe406a67 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q413629"@en ;
@@ -2539,13 +2539,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumCarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_584bfc73_2715_417f_973c_552ae58529f5
+###  https://w3id.org/emmo/chemicalsubstance#substance_584bfc73_2715_417f_973c_552ae58529f5
 :substance_584bfc73_2715_417f_973c_552ae58529f5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_6c490298_2ce8_41e1_ac37_4b44faff2d44 ;
                                                 skos:prefLabel "SodiumSaltCompound"@en .
 
 
-###  http://emmo.info/substance#substance_59168cd9_e3af_4345_96e9_88a80afd3d16
+###  https://w3id.org/emmo/chemicalsubstance#substance_59168cd9_e3af_4345_96e9_88a80afd3d16
 :substance_59168cd9_e3af_4345_96e9_88a80afd3d16 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a4a5b239_d88e_4e03_a763_0bf2a3dd0f47 ;
@@ -2559,7 +2559,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Magnesium"@en .
 
 
-###  http://emmo.info/substance#substance_597d0bee_eb9b_4264_9888_2c1400690a5d
+###  https://w3id.org/emmo/chemicalsubstance#substance_597d0bee_eb9b_4264_9888_2c1400690a5d
 :substance_597d0bee_eb9b_4264_9888_2c1400690a5d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2937970"@en ;
@@ -2572,7 +2572,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumHexafluorophosphate"@en .
 
 
-###  http://emmo.info/substance#substance_59c65403_b7f9_4852_a37a_e6295c7b026c
+###  https://w3id.org/emmo/chemicalsubstance#substance_59c65403_b7f9_4852_a37a_e6295c7b026c
 :substance_59c65403_b7f9_4852_a37a_e6295c7b026c rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -2586,7 +2586,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NMethyl2Pyrrolidone"@en .
 
 
-###  http://emmo.info/substance#substance_59db0926_27f3_444d_b3b7_126e9ea0b8e3
+###  https://w3id.org/emmo/chemicalsubstance#substance_59db0926_27f3_444d_b3b7_126e9ea0b8e3
 :substance_59db0926_27f3_444d_b3b7_126e9ea0b8e3 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204952"@en ;
@@ -2599,19 +2599,19 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincSulfide"@en .
 
 
-###  http://emmo.info/substance#substance_5a4d05f1_dd15_465b_8b44_704238e20813
+###  https://w3id.org/emmo/chemicalsubstance#substance_5a4d05f1_dd15_465b_8b44_704238e20813
 :substance_5a4d05f1_dd15_465b_8b44_704238e20813 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "ManganeseOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4
+###  https://w3id.org/emmo/chemicalsubstance#substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4
 :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f07ae87e_b56e_4835_8a28_04c6c7dfbaa2 ;
                                                 skos:prefLabel "Anion"@en .
 
 
-###  http://emmo.info/substance#substance_5a88a655_4e82_4b86_8636_50c70609536f
+###  https://w3id.org/emmo/chemicalsubstance#substance_5a88a655_4e82_4b86_8636_50c70609536f
 :substance_5a88a655_4e82_4b86_8636_50c70609536f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411848"@en ;
@@ -2624,7 +2624,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIIChloride"@en .
 
 
-###  http://emmo.info/substance#substance_5b24c742_1149_4533_8d48_41473396d06d
+###  https://w3id.org/emmo/chemicalsubstance#substance_5b24c742_1149_4533_8d48_41473396d06d
 :substance_5b24c742_1149_4533_8d48_41473396d06d rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_de038959_9251_48d1_a141_3684f14d957f ;
@@ -2638,7 +2638,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Hydroxylamine "@en .
 
 
-###  http://emmo.info/substance#substance_5bc7a64d_ec8d_4350_9e03_67fac740d00a
+###  https://w3id.org/emmo/chemicalsubstance#substance_5bc7a64d_ec8d_4350_9e03_67fac740d00a
 :substance_5bc7a64d_ec8d_4350_9e03_67fac740d00a rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q3562143"@en ;
@@ -2651,7 +2651,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TrisPentafluorophenylBorane"@en .
 
 
-###  http://emmo.info/substance#substance_5ca70573_eeed_4fed_af97_32560b532ccd
+###  https://w3id.org/emmo/chemicalsubstance#substance_5ca70573_eeed_4fed_af97_32560b532ccd
 :substance_5ca70573_eeed_4fed_af97_32560b532ccd rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_001ca83b_5372_4d77_a836_4d48074b7e63 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2626625"@en ;
@@ -2664,7 +2664,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TitaniumIIIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_5ce53b37_1248_43b0_8862_ef4bff996dcf
+###  https://w3id.org/emmo/chemicalsubstance#substance_5ce53b37_1248_43b0_8862_ef4bff996dcf
 :substance_5ce53b37_1248_43b0_8862_ef4bff996dcf rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -2677,7 +2677,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Niobium"@en .
 
 
-###  http://emmo.info/substance#substance_5cee19d2_f916_4264_a8ed_efed13a808d2
+###  https://w3id.org/emmo/chemicalsubstance#substance_5cee19d2_f916_4264_a8ed_efed13a808d2
 :substance_5cee19d2_f916_4264_a8ed_efed13a808d2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_6c0cc397_d8c4_4473_a09f_1e5de568e0dd ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q105038172"@en ;
@@ -2685,7 +2685,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "HardCarbon"@en .
 
 
-###  http://emmo.info/substance#substance_5d128b6c_3e70_470c_b24e_0b953ef76486
+###  https://w3id.org/emmo/chemicalsubstance#substance_5d128b6c_3e70_470c_b24e_0b953ef76486
 :substance_5d128b6c_3e70_470c_b24e_0b953ef76486 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/79119" ;
@@ -2696,7 +2696,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ThreeMeSulfolane"@en .
 
 
-###  http://emmo.info/substance#substance_5e44fe20_093d_4848_84ef_a20d69c17f3f
+###  https://w3id.org/emmo/chemicalsubstance#substance_5e44fe20_093d_4848_84ef_a20d69c17f3f
 :substance_5e44fe20_093d_4848_84ef_a20d69c17f3f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q339975"@en ;
@@ -2709,7 +2709,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumNitrite"@en .
 
 
-###  http://emmo.info/substance#substance_5fbecfe6_4d2f_467d_a301_f4698b0ea7dd
+###  https://w3id.org/emmo/chemicalsubstance#substance_5fbecfe6_4d2f_467d_a301_f4698b0ea7dd
 :substance_5fbecfe6_4d2f_467d_a301_f4698b0ea7dd rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -2722,7 +2722,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Molybdenum"@en .
 
 
-###  http://emmo.info/substance#substance_5fde02de_e08f_4854_9fe0_1e967bb3f60d
+###  https://w3id.org/emmo/chemicalsubstance#substance_5fde02de_e08f_4854_9fe0_1e967bb3f60d
 :substance_5fde02de_e08f_4854_9fe0_1e967bb3f60d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Cobalt(II)_carbonate"@en ;
@@ -2735,7 +2735,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIICarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_603164db_76c9_407b_be5c_8fa9b73f2dcc
+###  https://w3id.org/emmo/chemicalsubstance#substance_603164db_76c9_407b_be5c_8fa9b73f2dcc
 :substance_603164db_76c9_407b_be5c_8fa9b73f2dcc rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q417970"@en ;
@@ -2748,7 +2748,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumPerchlorate"@en .
 
 
-###  http://emmo.info/substance#substance_60441902_f7f6_4747_99c7_e15eb8c73706
+###  https://w3id.org/emmo/chemicalsubstance#substance_60441902_f7f6_4747_99c7_e15eb8c73706
 :substance_60441902_f7f6_4747_99c7_e15eb8c73706 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q27121260"@en ;
@@ -2760,7 +2760,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Trifluoromethanesulfonate"@en .
 
 
-###  http://emmo.info/substance#substance_60acd62d_2834_46b0_aca8_a4c497763d77
+###  https://w3id.org/emmo/chemicalsubstance#substance_60acd62d_2834_46b0_aca8_a4c497763d77
 :substance_60acd62d_2834_46b0_aca8_a4c497763d77 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_cac14194_2d5f_4fe6_b794_a9319f6d76ee ;
@@ -2773,7 +2773,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Xenon"@en .
 
 
-###  http://emmo.info/substance#substance_61250895_082a_46e8_8ce5_b8f6b3710866
+###  https://w3id.org/emmo/chemicalsubstance#substance_61250895_082a_46e8_8ce5_b8f6b3710866
 :substance_61250895_082a_46e8_8ce5_b8f6b3710866 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q18234771"@en ;
@@ -2785,13 +2785,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIIChlorate"@en .
 
 
-###  http://emmo.info/substance#substance_61c88366_7689_4814_b0c5_1f53aef1eebd
+###  https://w3id.org/emmo/chemicalsubstance#substance_61c88366_7689_4814_b0c5_1f53aef1eebd
 :substance_61c88366_7689_4814_b0c5_1f53aef1eebd rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ;
                                                 skos:prefLabel "PostTransitionMetalOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_62a815b7_247b_4c48_b83c_d52044f57236
+###  https://w3id.org/emmo/chemicalsubstance#substance_62a815b7_247b_4c48_b83c_d52044f57236
 :substance_62a815b7_247b_4c48_b83c_d52044f57236 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/102195117" ;
@@ -2801,14 +2801,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PDI"@en .
 
 
-###  http://emmo.info/substance#substance_62be6033_d836_4fc9_92d4_bd8cf2a9ce3a
+###  https://w3id.org/emmo/chemicalsubstance#substance_62be6033_d836_4fc9_92d4_bd8cf2a9ce3a
 :substance_62be6033_d836_4fc9_92d4_bd8cf2a9ce3a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 skos:altLabel "Mg(TFSI)2"@en ;
                                                 skos:prefLabel "MagnesiumBistrifluoromethanesulfonylimide"@en .
 
 
-###  http://emmo.info/substance#substance_6326d9bb_de83_4f60_beb3_3117280f8ab5
+###  https://w3id.org/emmo/chemicalsubstance#substance_6326d9bb_de83_4f60_beb3_3117280f8ab5
 :substance_6326d9bb_de83_4f60_beb3_3117280f8ab5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/29831" ;
@@ -2819,13 +2819,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ThreeMeTwoOxazolidinone"@en .
 
 
-###  http://emmo.info/substance#substance_63788521_5764_4ee2_8d8a_ce4978682546
+###  https://w3id.org/emmo/chemicalsubstance#substance_63788521_5764_4ee2_8d8a_ce4978682546
 :substance_63788521_5764_4ee2_8d8a_ce4978682546 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_015116fe_94ca_4be5_9d14_9d9457a47a72 ;
                                                 skos:prefLabel "IridiumSaltCompound"@en .
 
 
-###  http://emmo.info/substance#substance_63797ff9_c087_4033_a2e3_dd958e0b51e6
+###  https://w3id.org/emmo/chemicalsubstance#substance_63797ff9_c087_4033_a2e3_dd958e0b51e6
 :substance_63797ff9_c087_4033_a2e3_dd958e0b51e6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1985595"@en ;
@@ -2838,7 +2838,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIISulfide"@en .
 
 
-###  http://emmo.info/substance#substance_6400ba8f_97cf_4fa7_bc3b_aa2280bf5bea
+###  https://w3id.org/emmo/chemicalsubstance#substance_6400ba8f_97cf_4fa7_bc3b_aa2280bf5bea
 :substance_6400ba8f_97cf_4fa7_bc3b_aa2280bf5bea rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q113114521"@en ;
@@ -2850,7 +2850,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumDifluorophosphate"@en .
 
 
-###  http://emmo.info/substance#substance_6405fdd6_9ba7_436a_a9f1_56fd6bd3610f
+###  https://w3id.org/emmo/chemicalsubstance#substance_6405fdd6_9ba7_436a_a9f1_56fd6bd3610f
 :substance_6405fdd6_9ba7_436a_a9f1_56fd6bd3610f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q55583610"@en ;
@@ -2862,13 +2862,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIITetrafluoroborate"@en .
 
 
-###  http://emmo.info/substance#substance_6411d319_81a0_40f3_8e4d_09784d1c7644
+###  https://w3id.org/emmo/chemicalsubstance#substance_6411d319_81a0_40f3_8e4d_09784d1c7644
 :substance_6411d319_81a0_40f3_8e4d_09784d1c7644 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_61c88366_7689_4814_b0c5_1f53aef1eebd ;
                                                 skos:prefLabel "AluminiumOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_642ddaa3_0842_49c5_8bc9_2ae65f28da25
+###  https://w3id.org/emmo/chemicalsubstance#substance_642ddaa3_0842_49c5_8bc9_2ae65f28da25
 :substance_642ddaa3_0842_49c5_8bc9_2ae65f28da25 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q6647969"@en ;
@@ -2881,7 +2881,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumSulfite"@en .
 
 
-###  http://emmo.info/substance#substance_64bbeab1_1e9a_481e_8aaf_6fa629071818
+###  https://w3id.org/emmo/chemicalsubstance#substance_64bbeab1_1e9a_481e_8aaf_6fa629071818
 :substance_64bbeab1_1e9a_481e_8aaf_6fa629071818 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/14389160" ;
@@ -2892,7 +2892,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumHexafluorophosphate"@en .
 
 
-###  http://emmo.info/substance#substance_64d67eac_b2dc_45ad_9279_cff3a235e4e2
+###  https://w3id.org/emmo/chemicalsubstance#substance_64d67eac_b2dc_45ad_9279_cff3a235e4e2
 :substance_64d67eac_b2dc_45ad_9279_cff3a235e4e2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a4d05f1_dd15_465b_8b44_704238e20813 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q419605"@en ;
@@ -2905,7 +2905,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIIIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_65032a2b_f5ce_44e4_8798_6bd989e6785f
+###  https://w3id.org/emmo/chemicalsubstance#substance_65032a2b_f5ce_44e4_8798_6bd989e6785f
 :substance_65032a2b_f5ce_44e4_8798_6bd989e6785f rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_bed1a22c_8b61_467a_86a0_d24c7b910653 ;
@@ -2919,7 +2919,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumHydroxide"@en .
 
 
-###  http://emmo.info/substance#substance_651da334_c9a7_4658_998e_03533b5316f6
+###  https://w3id.org/emmo/chemicalsubstance#substance_651da334_c9a7_4658_998e_03533b5316f6
 :substance_651da334_c9a7_4658_998e_03533b5316f6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q420300"@en ;
@@ -2932,14 +2932,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIIBromide"@en .
 
 
-###  http://emmo.info/substance#substance_656bd621_963a_4ff0_b606_7e5a952bda3a
+###  https://w3id.org/emmo/chemicalsubstance#substance_656bd621_963a_4ff0_b606_7e5a952bda3a
 :substance_656bd621_963a_4ff0_b606_7e5a952bda3a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 skos:altLabel "Zn(TFSI)2"@en ;
                                                 skos:prefLabel "ZincBistrifluoromethanesulfonylimide"@en .
 
 
-###  http://emmo.info/substance#substance_66ceb100_8123_4393_9b57_7e1899954600
+###  https://w3id.org/emmo/chemicalsubstance#substance_66ceb100_8123_4393_9b57_7e1899954600
 :substance_66ceb100_8123_4393_9b57_7e1899954600 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/155293661" ;
@@ -2950,7 +2950,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumDifluorooxalatoborate"@en .
 
 
-###  http://emmo.info/substance#substance_6861354b_cb5b_415d_b970_9b11235b4775
+###  https://w3id.org/emmo/chemicalsubstance#substance_6861354b_cb5b_415d_b970_9b11235b4775
 :substance_6861354b_cb5b_415d_b970_9b11235b4775 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a4d05f1_dd15_465b_8b44_704238e20813 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q410985"@en ;
@@ -2963,7 +2963,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseII_IIIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_68c0876b_cb62_41cd_846d_95cc9d9a8733
+###  https://w3id.org/emmo/chemicalsubstance#substance_68c0876b_cb62_41cd_846d_95cc9d9a8733
 :substance_68c0876b_cb62_41cd_846d_95cc9d9a8733 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a9a6507f_9c61_44d3_bd86_f1ebf763e150 ;
@@ -2977,13 +2977,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Silicon"@en .
 
 
-###  http://emmo.info/substance#substance_68e4028b_0ec6_46da_8d1c_d00c644e8c82
+###  https://w3id.org/emmo/chemicalsubstance#substance_68e4028b_0ec6_46da_8d1c_d00c644e8c82
 :substance_68e4028b_0ec6_46da_8d1c_d00c644e8c82 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ;
                                                 skos:prefLabel "AlkaliMetalElementalSubstance"@en .
 
 
-###  http://emmo.info/substance#substance_68f9b85e_340f_46ec_96da_ebb6bd62f5fd
+###  https://w3id.org/emmo/chemicalsubstance#substance_68f9b85e_340f_46ec_96da_ebb6bd62f5fd
 :substance_68f9b85e_340f_46ec_96da_ebb6bd62f5fd rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q15730218"@en ;
@@ -2994,7 +2994,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumChromiumOxide"@en .
 
 
-###  http://emmo.info/substance#substance_6928f0e0_767e_4f33_a18e_e3041bf7d9e9
+###  https://w3id.org/emmo/chemicalsubstance#substance_6928f0e0_767e_4f33_a18e_e3041bf7d9e9
 :substance_6928f0e0_767e_4f33_a18e_e3041bf7d9e9 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q6748768"@en ;
@@ -3007,7 +3007,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIIPhosphate"@en .
 
 
-###  http://emmo.info/substance#substance_6970bc02_dfe3_40c7_b20d_03c6cc0707bb
+###  https://w3id.org/emmo/chemicalsubstance#substance_6970bc02_dfe3_40c7_b20d_03c6cc0707bb
 :substance_6970bc02_dfe3_40c7_b20d_03c6cc0707bb rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_b978912b_19ef_4d46_8c91_2e3578b12670 ;
@@ -3020,7 +3020,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Thallium"@en .
 
 
-###  http://emmo.info/substance#substance_69c32d36_9bbc_4b93_9016_e73d24c24d71
+###  https://w3id.org/emmo/chemicalsubstance#substance_69c32d36_9bbc_4b93_9016_e73d24c24d71
 :substance_69c32d36_9bbc_4b93_9016_e73d24c24d71 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q209444"@en ;
@@ -3034,7 +3034,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TwoMeTHF"@en .
 
 
-###  http://emmo.info/substance#substance_6a2432b3_abf1_4eba_825f_f0022ccba884
+###  https://w3id.org/emmo/chemicalsubstance#substance_6a2432b3_abf1_4eba_825f_f0022ccba884
 :substance_6a2432b3_abf1_4eba_825f_f0022ccba884 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409057"@en ;
@@ -3047,7 +3047,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumFluoride"@en .
 
 
-###  http://emmo.info/substance#substance_6a733ffe_5a00_40c5_b9b2_52e339a4c804
+###  https://w3id.org/emmo/chemicalsubstance#substance_6a733ffe_5a00_40c5_b9b2_52e339a4c804
 :substance_6a733ffe_5a00_40c5_b9b2_52e339a4c804 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q417856"@en ;
@@ -3060,7 +3060,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIICarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_6ae86cdf_2cd2_448a_8d6e_5a3bc5e12549
+###  https://w3id.org/emmo/chemicalsubstance#substance_6ae86cdf_2cd2_448a_8d6e_5a3bc5e12549
 :substance_6ae86cdf_2cd2_448a_8d6e_5a3bc5e12549 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q3680923"@en ;
@@ -3073,7 +3073,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincChlorate"@en .
 
 
-###  http://emmo.info/substance#substance_6bf6b561_381d_4d69_bc25_dbdd322db18c
+###  https://w3id.org/emmo/chemicalsubstance#substance_6bf6b561_381d_4d69_bc25_dbdd322db18c
 :substance_6bf6b561_381d_4d69_bc25_dbdd322db18c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q193054"@en ;
@@ -3086,13 +3086,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumSulfate"@en .
 
 
-###  http://emmo.info/substance#substance_6c0cc397_d8c4_4473_a09f_1e5de568e0dd
+###  https://w3id.org/emmo/chemicalsubstance#substance_6c0cc397_d8c4_4473_a09f_1e5de568e0dd
 :substance_6c0cc397_d8c4_4473_a09f_1e5de568e0dd rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ;
                                                 skos:prefLabel "CarbonElementalSubstance"@en .
 
 
-###  http://emmo.info/substance#substance_6c4110ec_f268_48b5_bbb5_38fe95737122
+###  https://w3id.org/emmo/chemicalsubstance#substance_6c4110ec_f268_48b5_bbb5_38fe95737122
 :substance_6c4110ec_f268_48b5_bbb5_38fe95737122 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q3375145"@en ;
@@ -3105,27 +3105,27 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumPerchlorate"@en .
 
 
-###  http://emmo.info/substance#substance_6c490298_2ce8_41e1_ac37_4b44faff2d44
+###  https://w3id.org/emmo/chemicalsubstance#substance_6c490298_2ce8_41e1_ac37_4b44faff2d44
 :substance_6c490298_2ce8_41e1_ac37_4b44faff2d44 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_edae7b22_461b_432b_b737_3c93feb69b0e ;
                                                 skos:prefLabel "AlkaliMetalSaltCompound"@en .
 
 
-###  http://emmo.info/substance#substance_6cdc8512_d4f2_4904_8471_3121871d48e8
+###  https://w3id.org/emmo/chemicalsubstance#substance_6cdc8512_d4f2_4904_8471_3121871d48e8
 :substance_6cdc8512_d4f2_4904_8471_3121871d48e8 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 skos:altLabel "BOP"@en ;
                                                 skos:prefLabel "LithiumBisoxalatophosphate"@en .
 
 
-###  http://emmo.info/substance#substance_6ce8569b_1367_4afd_954b_10eaccb8167c
+###  https://w3id.org/emmo/chemicalsubstance#substance_6ce8569b_1367_4afd_954b_10eaccb8167c
 :substance_6ce8569b_1367_4afd_954b_10eaccb8167c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 skos:altLabel "Sr(DFOB)2"@en ;
                                                 skos:prefLabel "StrontiumDifluorooxalatoborate"@en .
 
 
-###  http://emmo.info/substance#substance_6cfae78f_ccca_40ec_b80d_ec09595cca95
+###  https://w3id.org/emmo/chemicalsubstance#substance_6cfae78f_ccca_40ec_b80d_ec09595cca95
 :substance_6cfae78f_ccca_40ec_b80d_ec09595cca95 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a4d05f1_dd15_465b_8b44_704238e20813 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q414669"@en ;
@@ -3138,7 +3138,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_6d158508_abf0_4e10_beea_1d940da5fed1
+###  https://w3id.org/emmo/chemicalsubstance#substance_6d158508_abf0_4e10_beea_1d940da5fed1
 :substance_6d158508_abf0_4e10_beea_1d940da5fed1 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_78400dc0_97b0_4d59_8ea6_30bb703f428c ;
@@ -3152,7 +3152,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Iodine"@en .
 
 
-###  http://emmo.info/substance#substance_6d22feec_8b09_41ee_a98c_4eae316d445b
+###  https://w3id.org/emmo/chemicalsubstance#substance_6d22feec_8b09_41ee_a98c_4eae316d445b
 :substance_6d22feec_8b09_41ee_a98c_4eae316d445b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q215281"@en ;
@@ -3165,7 +3165,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIINitrate"@en .
 
 
-###  http://emmo.info/substance#substance_6d49be7e_bdd1_4d3b_bb95_d28047800a34
+###  https://w3id.org/emmo/chemicalsubstance#substance_6d49be7e_bdd1_4d3b_bb95_d28047800a34
 :substance_6d49be7e_bdd1_4d3b_bb95_d28047800a34 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4202653"@en ;
@@ -3178,7 +3178,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIIIodide"@en .
 
 
-###  http://emmo.info/substance#substance_6dd0f601_64e2_4216_be62_cb80ee28f016
+###  https://w3id.org/emmo/chemicalsubstance#substance_6dd0f601_64e2_4216_be62_cb80ee28f016
 :substance_6dd0f601_64e2_4216_be62_cb80ee28f016 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204661"@en ;
@@ -3191,7 +3191,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincCarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_6e5726c5_0589_4a2a_bdf4_3bece3121df5
+###  https://w3id.org/emmo/chemicalsubstance#substance_6e5726c5_0589_4a2a_bdf4_3bece3121df5
 :substance_6e5726c5_0589_4a2a_bdf4_3bece3121df5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q361627"@en ;
@@ -3204,7 +3204,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumPerchlorate"@en .
 
 
-###  http://emmo.info/substance#substance_6ec58a26_3a58_4f9f_a1ff_7858e7668bf0
+###  https://w3id.org/emmo/chemicalsubstance#substance_6ec58a26_3a58_4f9f_a1ff_7858e7668bf0
 :substance_6ec58a26_3a58_4f9f_a1ff_7858e7668bf0 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407520"@en ;
@@ -3217,7 +3217,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumFluoride"@en .
 
 
-###  http://emmo.info/substance#substance_6ec62f7b_2168_423f_81d2_4555fa29415e
+###  https://w3id.org/emmo/chemicalsubstance#substance_6ec62f7b_2168_423f_81d2_4555fa29415e
 :substance_6ec62f7b_2168_423f_81d2_4555fa29415e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q15628157"@en ;
@@ -3230,7 +3230,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIIPerchlorate"@en .
 
 
-###  http://emmo.info/substance#substance_73ce979c_af17_4187_81a7_7206bde39ec6
+###  https://w3id.org/emmo/chemicalsubstance#substance_73ce979c_af17_4187_81a7_7206bde39ec6
 :substance_73ce979c_af17_4187_81a7_7206bde39ec6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407392"@en ;
@@ -3243,7 +3243,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumNitrate"@en .
 
 
-###  http://emmo.info/substance#substance_73d4606c_7460_4a5c_9413_793bdf35753e
+###  https://w3id.org/emmo/chemicalsubstance#substance_73d4606c_7460_4a5c_9413_793bdf35753e
 :substance_73d4606c_7460_4a5c_9413_793bdf35753e rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_b978912b_19ef_4d46_8c91_2e3578b12670 ;
@@ -3256,7 +3256,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Gallium"@en .
 
 
-###  http://emmo.info/substance#substance_74bd7b49_4dd1_4093_8a4c_8b27a7998d05
+###  https://w3id.org/emmo/chemicalsubstance#substance_74bd7b49_4dd1_4093_8a4c_8b27a7998d05
 :substance_74bd7b49_4dd1_4093_8a4c_8b27a7998d05 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q15425780"@en ;
@@ -3269,7 +3269,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIINitrite"@en .
 
 
-###  http://emmo.info/substance#substance_74d63619_6ed6_4571_9a82_e27576c1ef32
+###  https://w3id.org/emmo/chemicalsubstance#substance_74d63619_6ed6_4571_9a82_e27576c1ef32
 :substance_74d63619_6ed6_4571_9a82_e27576c1ef32 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q309328"@en ;
@@ -3282,7 +3282,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumChlorate"@en .
 
 
-###  http://emmo.info/substance#substance_75322d4d_cdab_44c6_a8ea_5eca76bcfbd1
+###  https://w3id.org/emmo/chemicalsubstance#substance_75322d4d_cdab_44c6_a8ea_5eca76bcfbd1
 :substance_75322d4d_cdab_44c6_a8ea_5eca76bcfbd1 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q3788669"@en ;
@@ -3298,7 +3298,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Tetraglyme"@en .
 
 
-###  http://emmo.info/substance#substance_7550d4bb_59fd_41a3_aecb_4d45a03eaa28
+###  https://w3id.org/emmo/chemicalsubstance#substance_7550d4bb_59fd_41a3_aecb_4d45a03eaa28
 :substance_7550d4bb_59fd_41a3_aecb_4d45a03eaa28 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q425473"@en ;
@@ -3310,7 +3310,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TartronicAcid"@en .
 
 
-###  http://emmo.info/substance#substance_761bcae6_b46b_4002_8601_474132fba6d8
+###  https://w3id.org/emmo/chemicalsubstance#substance_761bcae6_b46b_4002_8601_474132fba6d8
 :substance_761bcae6_b46b_4002_8601_474132fba6d8 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_cac14194_2d5f_4fe6_b794_a9319f6d76ee ;
@@ -3324,7 +3324,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Helium"@en .
 
 
-###  http://emmo.info/substance#substance_761c90b7_61f7_495a_a5e7_a00afb14e41f
+###  https://w3id.org/emmo/chemicalsubstance#substance_761c90b7_61f7_495a_a5e7_a00afb14e41f
 :substance_761c90b7_61f7_495a_a5e7_a00afb14e41f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204828"@en ;
@@ -3337,7 +3337,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincIodide"@en .
 
 
-###  http://emmo.info/substance#substance_769bdc09_f533_4fde_bb53_20339d5bfcb7
+###  https://w3id.org/emmo/chemicalsubstance#substance_769bdc09_f533_4fde_bb53_20339d5bfcb7
 :substance_769bdc09_f533_4fde_bb53_20339d5bfcb7 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -3351,7 +3351,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Dimethylformamide"@en .
 
 
-###  http://emmo.info/substance#substance_777a99d3_f2db_4c54_b093_85e3fbbe632d
+###  https://w3id.org/emmo/chemicalsubstance#substance_777a99d3_f2db_4c54_b093_85e3fbbe632d
 :substance_777a99d3_f2db_4c54_b093_85e3fbbe632d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q415500"@en ;
@@ -3364,13 +3364,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIIChloride"@en .
 
 
-###  http://emmo.info/substance#substance_78400dc0_97b0_4d59_8ea6_30bb703f428c
+###  https://w3id.org/emmo/chemicalsubstance#substance_78400dc0_97b0_4d59_8ea6_30bb703f428c
 :substance_78400dc0_97b0_4d59_8ea6_30bb703f428c rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ;
                                                 skos:prefLabel "ReactiveNonMetalElementalSubstance"@en .
 
 
-###  http://emmo.info/substance#substance_788494aa_e502_4b8d_8e3a_883d14d3ed98
+###  https://w3id.org/emmo/chemicalsubstance#substance_788494aa_e502_4b8d_8e3a_883d14d3ed98
 :substance_788494aa_e502_4b8d_8e3a_883d14d3ed98 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_8e5448fc_1916_4afb_9fd9_2489797f6922 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72461389"@en ;
@@ -3383,7 +3383,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperHydroxide"@en .
 
 
-###  http://emmo.info/substance#substance_789fa169_2e2c_4a82_9c4a_aecebda6a9ab
+###  https://w3id.org/emmo/chemicalsubstance#substance_789fa169_2e2c_4a82_9c4a_aecebda6a9ab
 :substance_789fa169_2e2c_4a82_9c4a_aecebda6a9ab rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7e716191_b301_4d63_bb6b_93323ffe51bf ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409762"@en ;
@@ -3396,7 +3396,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PolyacrylicAcid"@en .
 
 
-###  http://emmo.info/substance#substance_78a1367d_61b4_40a4_9c22_fdd0017f535f
+###  https://w3id.org/emmo/chemicalsubstance#substance_78a1367d_61b4_40a4_9c22_fdd0017f535f
 :substance_78a1367d_61b4_40a4_9c22_fdd0017f535f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q193213"@en ;
@@ -3408,7 +3408,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ButanoicAcid"@en .
 
 
-###  http://emmo.info/substance#substance_79220ea3_3426_47a0_9b41_33012d565fc2
+###  https://w3id.org/emmo/chemicalsubstance#substance_79220ea3_3426_47a0_9b41_33012d565fc2
 :substance_79220ea3_3426_47a0_9b41_33012d565fc2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7e716191_b301_4d63_bb6b_93323ffe51bf ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q143429"@en ;
@@ -3417,7 +3417,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Polyethylene"@en .
 
 
-###  http://emmo.info/substance#substance_79614448_5a32_49e2_a690_3b5ff59ba5b7
+###  https://w3id.org/emmo/chemicalsubstance#substance_79614448_5a32_49e2_a690_3b5ff59ba5b7
 :substance_79614448_5a32_49e2_a690_3b5ff59ba5b7 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q419684"@en ;
@@ -3430,7 +3430,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIIBromide"@en .
 
 
-###  http://emmo.info/substance#substance_79b93232_d05a_445f_a365_659a64362dde
+###  https://w3id.org/emmo/chemicalsubstance#substance_79b93232_d05a_445f_a365_659a64362dde
 :substance_79b93232_d05a_445f_a365_659a64362dde rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421174"@en ;
@@ -3443,7 +3443,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumFluoride"@en .
 
 
-###  http://emmo.info/substance#substance_7a613ca4_0c7b_463e_a48c_2e3b30b21c8a
+###  https://w3id.org/emmo/chemicalsubstance#substance_7a613ca4_0c7b_463e_a48c_2e3b30b21c8a
 :substance_7a613ca4_0c7b_463e_a48c_2e3b30b21c8a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q379885"@en ;
@@ -3456,7 +3456,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumCarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_7a757020_eecc_4dc1_afc7_55759911c772
+###  https://w3id.org/emmo/chemicalsubstance#substance_7a757020_eecc_4dc1_afc7_55759911c772
 :substance_7a757020_eecc_4dc1_afc7_55759911c772 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dc68514f_b592_4e1b_a00f_fbb29f2fafbd ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/11161794" ;
@@ -3466,7 +3466,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Aquivion"@en .
 
 
-###  http://emmo.info/substance#substance_7bc25dd0_8096_4ca0_98f3_03fb847f82e7
+###  https://w3id.org/emmo/chemicalsubstance#substance_7bc25dd0_8096_4ca0_98f3_03fb847f82e7
 :substance_7bc25dd0_8096_4ca0_98f3_03fb847f82e7 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q190143"@en ;
@@ -3478,7 +3478,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MalicAcid"@en .
 
 
-###  http://emmo.info/substance#substance_7bebc661_c77b_4124_bed3_c2ac6346a2a6
+###  https://w3id.org/emmo/chemicalsubstance#substance_7bebc661_c77b_4124_bed3_c2ac6346a2a6
 :substance_7bebc661_c77b_4124_bed3_c2ac6346a2a6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q419721"@en ;
@@ -3491,7 +3491,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumChlorate"@en .
 
 
-###  http://emmo.info/substance#substance_7beec353_bad9_46fc_a035_a76b131fb32b
+###  https://w3id.org/emmo/chemicalsubstance#substance_7beec353_bad9_46fc_a035_a76b131fb32b
 :substance_7beec353_bad9_46fc_a035_a76b131fb32b rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ;
                                                 owl:disjointWith :substance_cc155ed5_c60c_4d9f_bfad_fbf6b7c77e57 ;
@@ -3504,7 +3504,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Base"@en .
 
 
-###  http://emmo.info/substance#substance_7c919833_aea5_4029_a0db_2289444ec2a5
+###  https://w3id.org/emmo/chemicalsubstance#substance_7c919833_aea5_4029_a0db_2289444ec2a5
 :substance_7c919833_aea5_4029_a0db_2289444ec2a5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409701"@en ;
@@ -3517,14 +3517,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumBromide"@en .
 
 
-###  http://emmo.info/substance#substance_7cb7c122_995f_43d3_b419_b8a0d0fe8406
+###  https://w3id.org/emmo/chemicalsubstance#substance_7cb7c122_995f_43d3_b419_b8a0d0fe8406
 :substance_7cb7c122_995f_43d3_b419_b8a0d0fe8406 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 skos:altLabel "Ba(FSI)2"@en ;
                                                 skos:prefLabel "BariumBisfluorosulfonylimide"@en .
 
 
-###  http://emmo.info/substance#substance_7d024df4_884b_4de3_b6f1_28af090356c3
+###  https://w3id.org/emmo/chemicalsubstance#substance_7d024df4_884b_4de3_b6f1_28af090356c3
 :substance_7d024df4_884b_4de3_b6f1_28af090356c3 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q27292536"@en ;
@@ -3536,7 +3536,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIITetrafluoroborate"@en .
 
 
-###  http://emmo.info/substance#substance_7dc738d6_74f2_489e_ae84_a6dbdf627f2e
+###  https://w3id.org/emmo/chemicalsubstance#substance_7dc738d6_74f2_489e_ae84_a6dbdf627f2e
 :substance_7dc738d6_74f2_489e_ae84_a6dbdf627f2e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b8c65e71_05de_4f07_acd8_a16938b550fd ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q23927502"@en ;
@@ -3549,19 +3549,19 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelOxideHydroxide"@en .
 
 
-###  http://emmo.info/substance#substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84
+###  https://w3id.org/emmo/chemicalsubstance#substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84
 :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_fc93282d_cb35_4bab_81a8_78689ae59e5f ;
                                                 skos:prefLabel "BariumSaltCompound"@en .
 
 
-###  http://emmo.info/substance#substance_7e716191_b301_4d63_bb6b_93323ffe51bf
+###  https://w3id.org/emmo/chemicalsubstance#substance_7e716191_b301_4d63_bb6b_93323ffe51bf
 :substance_7e716191_b301_4d63_bb6b_93323ffe51bf rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 skos:prefLabel "PolymerCompound"@en .
 
 
-###  http://emmo.info/substance#substance_7e9bbc33_c681_467a_b0d7_5de0e71230b4
+###  https://w3id.org/emmo/chemicalsubstance#substance_7e9bbc33_c681_467a_b0d7_5de0e71230b4
 :substance_7e9bbc33_c681_467a_b0d7_5de0e71230b4 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q81982574"@en ;
@@ -3573,7 +3573,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Bis(oxalato)borate"@en .
 
 
-###  http://emmo.info/substance#substance_7fa9e820_f244_4929_a926_a6ebf85014ba
+###  https://w3id.org/emmo/chemicalsubstance#substance_7fa9e820_f244_4929_a926_a6ebf85014ba
 :substance_7fa9e820_f244_4929_a926_a6ebf85014ba rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q55573807"@en ;
@@ -3585,13 +3585,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumTriflate"@en .
 
 
-###  http://emmo.info/substance#substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150
+###  https://w3id.org/emmo/chemicalsubstance#substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150
 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 ;
                                                 skos:prefLabel "AproticSolventCompound"@en .
 
 
-###  http://emmo.info/substance#substance_7fdf54d6_5503_4f83_8627_537805542c5b
+###  https://w3id.org/emmo/chemicalsubstance#substance_7fdf54d6_5503_4f83_8627_537805542c5b
 :substance_7fdf54d6_5503_4f83_8627_537805542c5b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411656"@en ;
@@ -3604,7 +3604,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumSulfide"@en .
 
 
-###  http://emmo.info/substance#substance_8010a0fa_2147_41bc_a6b6_1da62fa7d939
+###  https://w3id.org/emmo/chemicalsubstance#substance_8010a0fa_2147_41bc_a6b6_1da62fa7d939
 :substance_8010a0fa_2147_41bc_a6b6_1da62fa7d939 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a639df56_1fb2_47f3_8069_c929b5a84b86 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409173"@en ;
@@ -3617,7 +3617,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "VanadiumVOxide"@en .
 
 
-###  http://emmo.info/substance#substance_8018d7e8_c3f3_411e_adda_644bbd53338d
+###  https://w3id.org/emmo/chemicalsubstance#substance_8018d7e8_c3f3_411e_adda_644bbd53338d
 :substance_8018d7e8_c3f3_411e_adda_644bbd53338d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_8f1af9c2_9b6d_44f4_8f55_70a4cd5f9dde ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4332819"@en ;
@@ -3628,7 +3628,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_8069b9ca_4639_49c6_b182_fedff62869a1
+###  https://w3id.org/emmo/chemicalsubstance#substance_8069b9ca_4639_49c6_b182_fedff62869a1
 :substance_8069b9ca_4639_49c6_b182_fedff62869a1 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a4a5b239_d88e_4e03_a763_0bf2a3dd0f47 ;
@@ -3642,7 +3642,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Calcium"@en .
 
 
-###  http://emmo.info/substance#substance_815f5532_e1d0_48e5_bc2b_b3b7d018f032
+###  https://w3id.org/emmo/chemicalsubstance#substance_815f5532_e1d0_48e5_bc2b_b3b7d018f032
 :substance_815f5532_e1d0_48e5_bc2b_b3b7d018f032 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409630"@en ;
@@ -3655,7 +3655,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIICarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_817d1989_4d6d_4c32_9951_85973afc538d
+###  https://w3id.org/emmo/chemicalsubstance#substance_817d1989_4d6d_4c32_9951_85973afc538d
 :substance_817d1989_4d6d_4c32_9951_85973afc538d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409298"@en ;
@@ -3669,13 +3669,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Dimethylformamide"@en .
 
 
-###  http://emmo.info/substance#substance_81b90332_8b8e_407b_a8fd_517306d56a59
+###  https://w3id.org/emmo/chemicalsubstance#substance_81b90332_8b8e_407b_a8fd_517306d56a59
 :substance_81b90332_8b8e_407b_a8fd_517306d56a59 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ;
                                                 skos:prefLabel "SolventCompound"@en .
 
 
-###  http://emmo.info/substance#substance_8267551d_7572_42f6_888d_96ff0c78f3aa
+###  https://w3id.org/emmo/chemicalsubstance#substance_8267551d_7572_42f6_888d_96ff0c78f3aa
 :substance_8267551d_7572_42f6_888d_96ff0c78f3aa rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q27273378"@en ;
@@ -3688,14 +3688,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumBistrifluoromethanesulfonylimide"@en .
 
 
-###  http://emmo.info/substance#substance_82d57014_0870_45f3_ab05_0f97c05b531d
+###  https://w3id.org/emmo/chemicalsubstance#substance_82d57014_0870_45f3_ab05_0f97c05b531d
 :substance_82d57014_0870_45f3_ab05_0f97c05b531d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 skos:altLabel "Mg(DFOB)2"@en ;
                                                 skos:prefLabel "MagnesiumDifluorooxalatoborate"@en .
 
 
-###  http://emmo.info/substance#substance_83285f8c_bbf3_4548_9599_bc8c327fc099
+###  https://w3id.org/emmo/chemicalsubstance#substance_83285f8c_bbf3_4548_9599_bc8c327fc099
 :substance_83285f8c_bbf3_4548_9599_bc8c327fc099 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_8e5448fc_1916_4afb_9fd9_2489797f6922 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q420717"@en ;
@@ -3708,7 +3708,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CadmiumHydroxide"@en .
 
 
-###  http://emmo.info/substance#substance_835df324_98ae_44c2_a0ff_bd9142240b8c
+###  https://w3id.org/emmo/chemicalsubstance#substance_835df324_98ae_44c2_a0ff_bd9142240b8c
 :substance_835df324_98ae_44c2_a0ff_bd9142240b8c rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_f5b930f9_2f95_4268_993c_ff6b57ae7691 ;
@@ -3722,7 +3722,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "HydrogenIodide"@en .
 
 
-###  http://emmo.info/substance#substance_8385c3c4_5906_48f6_b6b6_4bb60dccc27a
+###  https://w3id.org/emmo/chemicalsubstance#substance_8385c3c4_5906_48f6_b6b6_4bb60dccc27a
 :substance_8385c3c4_5906_48f6_b6b6_4bb60dccc27a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421748"@en ;
@@ -3737,7 +3737,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Dichloromethane"@en .
 
 
-###  http://emmo.info/substance#substance_843697d9_5863_4959_9163_5b58dba6a3f0
+###  https://w3id.org/emmo/chemicalsubstance#substance_843697d9_5863_4959_9163_5b58dba6a3f0
 :substance_843697d9_5863_4959_9163_5b58dba6a3f0 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q419893"@en ;
@@ -3750,7 +3750,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIISulfide"@en .
 
 
-###  http://emmo.info/substance#substance_846f0b5b_cdf5_4a12_938b_75d9312e02b3
+###  https://w3id.org/emmo/chemicalsubstance#substance_846f0b5b_cdf5_4a12_938b_75d9312e02b3
 :substance_846f0b5b_cdf5_4a12_938b_75d9312e02b3 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q416969"@en ;
@@ -3763,7 +3763,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumAcetate"@en .
 
 
-###  http://emmo.info/substance#substance_847590b4_fae5_4f57_b1b0_1bb545528152
+###  https://w3id.org/emmo/chemicalsubstance#substance_847590b4_fae5_4f57_b1b0_1bb545528152
 :substance_847590b4_fae5_4f57_b1b0_1bb545528152 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q278387"@en ;
@@ -3776,7 +3776,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumPhosphate"@en .
 
 
-###  http://emmo.info/substance#substance_848003a2_71ee_4967_8039_354c907ec7f4
+###  https://w3id.org/emmo/chemicalsubstance#substance_848003a2_71ee_4967_8039_354c907ec7f4
 :substance_848003a2_71ee_4967_8039_354c907ec7f4 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_28754642_a1ed_4f39_8b00_2c7857336bab ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q190077"@en ;
@@ -3789,7 +3789,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincOxide"@en .
 
 
-###  http://emmo.info/substance#substance_8522bd08_3855_4e4b_bca0_30923a40de88
+###  https://w3id.org/emmo/chemicalsubstance#substance_8522bd08_3855_4e4b_bca0_30923a40de88
 :substance_8522bd08_3855_4e4b_bca0_30923a40de88 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_68e4028b_0ec6_46da_8d1c_d00c644e8c82 ;
@@ -3802,7 +3802,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Caesium"@en .
 
 
-###  http://emmo.info/substance#substance_859210f4_f4ac_445d_841c_74e3fbe74c3e
+###  https://w3id.org/emmo/chemicalsubstance#substance_859210f4_f4ac_445d_841c_74e3fbe74c3e
 :substance_859210f4_f4ac_445d_841c_74e3fbe74c3e rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -3815,7 +3815,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Tungsten"@en .
 
 
-###  http://emmo.info/substance#substance_860eab87_6711_4b5b_90ca_50b6f4da7f67
+###  https://w3id.org/emmo/chemicalsubstance#substance_860eab87_6711_4b5b_90ca_50b6f4da7f67
 :substance_860eab87_6711_4b5b_90ca_50b6f4da7f67 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -3829,13 +3829,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Sulfolane"@en .
 
 
-###  http://emmo.info/substance#substance_878a0e2f_12ba_484e_8197_75e57139d207
+###  https://w3id.org/emmo/chemicalsubstance#substance_878a0e2f_12ba_484e_8197_75e57139d207
 :substance_878a0e2f_12ba_484e_8197_75e57139d207 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 ;
                                                 skos:prefLabel "ProticSolventCompound"@en .
 
 
-###  http://emmo.info/substance#substance_881dd19c_814c_4c58_9e67_f9c2494fec11
+###  https://w3id.org/emmo/chemicalsubstance#substance_881dd19c_814c_4c58_9e67_f9c2494fec11
 :substance_881dd19c_814c_4c58_9e67_f9c2494fec11 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407510"@en ;
@@ -3848,13 +3848,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumSulfide"@en .
 
 
-###  http://emmo.info/substance#substance_88748886_9b7c_4df0_91eb_fe91ecc1b9cd
+###  https://w3id.org/emmo/chemicalsubstance#substance_88748886_9b7c_4df0_91eb_fe91ecc1b9cd
 :substance_88748886_9b7c_4df0_91eb_fe91ecc1b9cd rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "ChromiumOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_88b6445a_0445_483f_88f4_6b910e901c08
+###  https://w3id.org/emmo/chemicalsubstance#substance_88b6445a_0445_483f_88f4_6b910e901c08
 :substance_88b6445a_0445_483f_88f4_6b910e901c08 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_68e4028b_0ec6_46da_8d1c_d00c644e8c82 ;
@@ -3867,7 +3867,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Potassium"@en .
 
 
-###  http://emmo.info/substance#substance_88d380f4_1207_4a30_a117_8472bb3d1d81
+###  https://w3id.org/emmo/chemicalsubstance#substance_88d380f4_1207_4a30_a117_8472bb3d1d81
 :substance_88d380f4_1207_4a30_a117_8472bb3d1d81 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4918589"@en ;
@@ -3880,7 +3880,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Bistriflimide"@en .
 
 
-###  http://emmo.info/substance#substance_89228db4_7491_40f1_bd25_c87e459a2d20
+###  https://w3id.org/emmo/chemicalsubstance#substance_89228db4_7491_40f1_bd25_c87e459a2d20
 :substance_89228db4_7491_40f1_bd25_c87e459a2d20 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q419503"@en ;
@@ -3893,7 +3893,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumPhosphate"@en .
 
 
-###  http://emmo.info/substance#substance_89898e91_c4c7_4057_8040_965d1776d2ba
+###  https://w3id.org/emmo/chemicalsubstance#substance_89898e91_c4c7_4057_8040_965d1776d2ba
 :substance_89898e91_c4c7_4057_8040_965d1776d2ba rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q314036"@en ;
@@ -3906,7 +3906,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumChloride"@en .
 
 
-###  http://emmo.info/substance#substance_899debc5_ad7c_4f0a_a68c_47fedca57364
+###  https://w3id.org/emmo/chemicalsubstance#substance_899debc5_ad7c_4f0a_a68c_47fedca57364
 :substance_899debc5_ad7c_4f0a_a68c_47fedca57364 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407806"@en ;
@@ -3919,7 +3919,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumSulfite"@en .
 
 
-###  http://emmo.info/substance#substance_89fd13e8_8061_41da_83f4_634144116425
+###  https://w3id.org/emmo/chemicalsubstance#substance_89fd13e8_8061_41da_83f4_634144116425
 :substance_89fd13e8_8061_41da_83f4_634144116425 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -3932,7 +3932,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Iron"@en .
 
 
-###  http://emmo.info/substance#substance_8a253be9_75a6_4da2_b875_4454d5aebef3
+###  https://w3id.org/emmo/chemicalsubstance#substance_8a253be9_75a6_4da2_b875_4454d5aebef3
 :substance_8a253be9_75a6_4da2_b875_4454d5aebef3 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q7624768"@en ;
@@ -3945,7 +3945,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumChlorate"@en .
 
 
-###  http://emmo.info/substance#substance_8a897ed1_a611_46bf_8252_502428a0bff7
+###  https://w3id.org/emmo/chemicalsubstance#substance_8a897ed1_a611_46bf_8252_502428a0bff7
 :substance_8a897ed1_a611_46bf_8252_502428a0bff7 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407258"@en ;
@@ -3958,7 +3958,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumSulfate"@en .
 
 
-###  http://emmo.info/substance#substance_8ab4c789_bad4_4b36_9f54_d8c6e9e7b5b2
+###  https://w3id.org/emmo/chemicalsubstance#substance_8ab4c789_bad4_4b36_9f54_d8c6e9e7b5b2
 :substance_8ab4c789_bad4_4b36_9f54_d8c6e9e7b5b2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q416913"@en ;
@@ -3970,7 +3970,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumSulfide"@en .
 
 
-###  http://emmo.info/substance#substance_8ab6b726_e711_41d7_b237_b21094383239
+###  https://w3id.org/emmo/chemicalsubstance#substance_8ab6b726_e711_41d7_b237_b21094383239
 :substance_8ab6b726_e711_41d7_b237_b21094383239 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/59687871" ;
@@ -3981,7 +3981,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Bis(malonato)borate"@en .
 
 
-###  http://emmo.info/substance#substance_8aeab71f_c07f_4eb6_9652_08ee27c29ffc
+###  https://w3id.org/emmo/chemicalsubstance#substance_8aeab71f_c07f_4eb6_9652_08ee27c29ffc
 :substance_8aeab71f_c07f_4eb6_9652_08ee27c29ffc rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q417658"@en ;
@@ -3994,7 +3994,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumSulfide"@en .
 
 
-###  http://emmo.info/substance#substance_8afd2477_9c49_4465_9910_6103732a3318
+###  https://w3id.org/emmo/chemicalsubstance#substance_8afd2477_9c49_4465_9910_6103732a3318
 :substance_8afd2477_9c49_4465_9910_6103732a3318 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4096880"@en ;
@@ -4007,7 +4007,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIBromide"@en .
 
 
-###  http://emmo.info/substance#substance_8b02cecd_75f9_47d6_8826_55c1a42f1c42
+###  https://w3id.org/emmo/chemicalsubstance#substance_8b02cecd_75f9_47d6_8826_55c1a42f1c42
 :substance_8b02cecd_75f9_47d6_8826_55c1a42f1c42 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q416904"@en ;
@@ -4020,13 +4020,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumBromide"@en .
 
 
-###  http://emmo.info/substance#substance_8c40be1f_0931_4db9_832f_cb63556f6a5a
+###  https://w3id.org/emmo/chemicalsubstance#substance_8c40be1f_0931_4db9_832f_cb63556f6a5a
 :substance_8c40be1f_0931_4db9_832f_cb63556f6a5a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_edae7b22_461b_432b_b737_3c93feb69b0e ;
                                                 skos:prefLabel "PostTransitionMetalSaltCompound"@en .
 
 
-###  http://emmo.info/substance#substance_8c49b4a2_00e2_421e_97af_9dde2a59ac69
+###  https://w3id.org/emmo/chemicalsubstance#substance_8c49b4a2_00e2_421e_97af_9dde2a59ac69
 :substance_8c49b4a2_00e2_421e_97af_9dde2a59ac69 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2396092"@en ;
@@ -4039,7 +4039,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumSulfite"@en .
 
 
-###  http://emmo.info/substance#substance_8c783453_0a52_4c20_9687_2b6ce2b95762
+###  https://w3id.org/emmo/chemicalsubstance#substance_8c783453_0a52_4c20_9687_2b6ce2b95762
 :substance_8c783453_0a52_4c20_9687_2b6ce2b95762 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1765041"@en ;
@@ -4052,7 +4052,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumSulfide"@en .
 
 
-###  http://emmo.info/substance#substance_8cbdf192_69bf_45cc_a570_95bf69fd8f91
+###  https://w3id.org/emmo/chemicalsubstance#substance_8cbdf192_69bf_45cc_a570_95bf69fd8f91
 :substance_8cbdf192_69bf_45cc_a570_95bf69fd8f91 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q808224"@en ;
@@ -4064,7 +4064,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumPhosphate"@en .
 
 
-###  http://emmo.info/substance#substance_8ce10627_f9f3_4520_a619_b407877e263b
+###  https://w3id.org/emmo/chemicalsubstance#substance_8ce10627_f9f3_4520_a619_b407877e263b
 :substance_8ce10627_f9f3_4520_a619_b407877e263b rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a9a6507f_9c61_44d3_bd86_f1ebf763e150 ;
@@ -4078,7 +4078,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Tellurium"@en .
 
 
-###  http://emmo.info/substance#substance_8cf9ae58_147a_4fb3_a3c8_972bb2fdcca0
+###  https://w3id.org/emmo/chemicalsubstance#substance_8cf9ae58_147a_4fb3_a3c8_972bb2fdcca0
 :substance_8cf9ae58_147a_4fb3_a3c8_972bb2fdcca0 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q419690"@en ;
@@ -4091,7 +4091,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIIFluoride"@en .
 
 
-###  http://emmo.info/substance#substance_8d866be8_fec3_4253_a388_ca6005fd9c85
+###  https://w3id.org/emmo/chemicalsubstance#substance_8d866be8_fec3_4253_a388_ca6005fd9c85
 :substance_8d866be8_fec3_4253_a388_ca6005fd9c85 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q412492"@en ;
@@ -4104,7 +4104,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumChlorate"@en .
 
 
-###  http://emmo.info/substance#substance_8dd87ac5_a8e1_4228_93bb_189e442fa71b
+###  https://w3id.org/emmo/chemicalsubstance#substance_8dd87ac5_a8e1_4228_93bb_189e442fa71b
 :substance_8dd87ac5_a8e1_4228_93bb_189e442fa71b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/14389155" ;
@@ -4115,19 +4115,19 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumHexafluorophosphate"@en .
 
 
-###  http://emmo.info/substance#substance_8e5448fc_1916_4afb_9fd9_2489797f6922
+###  https://w3id.org/emmo/chemicalsubstance#substance_8e5448fc_1916_4afb_9fd9_2489797f6922
 :substance_8e5448fc_1916_4afb_9fd9_2489797f6922 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7beec353_bad9_46fc_a035_a76b131fb32b ;
                                                 skos:prefLabel "WeakBaseCompound"@en .
 
 
-###  http://emmo.info/substance#substance_8f1af9c2_9b6d_44f4_8f55_70a4cd5f9dde
+###  https://w3id.org/emmo/chemicalsubstance#substance_8f1af9c2_9b6d_44f4_8f55_70a4cd5f9dde
 :substance_8f1af9c2_9b6d_44f4_8f55_70a4cd5f9dde rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_61c88366_7689_4814_b0c5_1f53aef1eebd ;
                                                 skos:prefLabel "IndiumOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_8f7dd877_5ad0_48f1_bbec_84153d8215f4
+###  https://w3id.org/emmo/chemicalsubstance#substance_8f7dd877_5ad0_48f1_bbec_84153d8215f4
 :substance_8f7dd877_5ad0_48f1_bbec_84153d8215f4 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_b978912b_19ef_4d46_8c91_2e3578b12670 ;
@@ -4140,7 +4140,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Aluminium"@en .
 
 
-###  http://emmo.info/substance#substance_8f857eb2_7cc8_4294_954d_e69f2842c084
+###  https://w3id.org/emmo/chemicalsubstance#substance_8f857eb2_7cc8_4294_954d_e69f2842c084
 :substance_8f857eb2_7cc8_4294_954d_e69f2842c084 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -4153,7 +4153,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Cobalt"@en .
 
 
-###  http://emmo.info/substance#substance_8f867fdb_27b7_4d6f_9628_98da5afcad5b
+###  https://w3id.org/emmo/chemicalsubstance#substance_8f867fdb_27b7_4d6f_9628_98da5afcad5b
 :substance_8f867fdb_27b7_4d6f_9628_98da5afcad5b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7e716191_b301_4d63_bb6b_93323ffe51bf ,
                                                                 :substance_961f7671_8708_4ce3_9c7d_79444adba9c0 ;
@@ -4163,7 +4163,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PolyvinylAlcohol"@en .
 
 
-###  http://emmo.info/substance#substance_8fd9909b_b99a_41a8_be0e_19f6717e5c2f
+###  https://w3id.org/emmo/chemicalsubstance#substance_8fd9909b_b99a_41a8_be0e_19f6717e5c2f
 :substance_8fd9909b_b99a_41a8_be0e_19f6717e5c2f rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72476692"@en ;
@@ -4175,7 +4175,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TwoFluoropyridine"@en .
 
 
-###  http://emmo.info/substance#substance_904b81d8_7d9c_45f4_95d7_e27ff9cebf17
+###  https://w3id.org/emmo/chemicalsubstance#substance_904b81d8_7d9c_45f4_95d7_e27ff9cebf17
 :substance_904b81d8_7d9c_45f4_95d7_e27ff9cebf17 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_bed1a22c_8b61_467a_86a0_d24c7b910653 ;
@@ -4189,7 +4189,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumHydroxide"@en .
 
 
-###  http://emmo.info/substance#substance_90f71119_f476_4033_b6ee_6342680322e5
+###  https://w3id.org/emmo/chemicalsubstance#substance_90f71119_f476_4033_b6ee_6342680322e5
 :substance_90f71119_f476_4033_b6ee_6342680322e5 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -4202,7 +4202,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Cadmium"@en .
 
 
-###  http://emmo.info/substance#substance_91890364_2be0_4333_ae45_f619cbf2d078
+###  https://w3id.org/emmo/chemicalsubstance#substance_91890364_2be0_4333_ae45_f619cbf2d078
 :substance_91890364_2be0_4333_ae45_f619cbf2d078 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204954"@en ;
@@ -4215,7 +4215,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincSulfate"@en .
 
 
-###  http://emmo.info/substance#substance_92a60b4f_7abf_46f9_824b_47ff7aa09c15
+###  https://w3id.org/emmo/chemicalsubstance#substance_92a60b4f_7abf_46f9_824b_47ff7aa09c15
 :substance_92a60b4f_7abf_46f9_824b_47ff7aa09c15 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q18212007"@en ;
@@ -4228,7 +4228,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIIPerchlorate"@en .
 
 
-###  http://emmo.info/substance#substance_945c68da_3baf_4da6_b794_dca7aebc4ca7
+###  https://w3id.org/emmo/chemicalsubstance#substance_945c68da_3baf_4da6_b794_dca7aebc4ca7
 :substance_945c68da_3baf_4da6_b794_dca7aebc4ca7 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -4242,7 +4242,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Dimethylpropyleneurea"@en .
 
 
-###  http://emmo.info/substance#substance_94af35ef_9e0d_4e4d_b794_ee0a14706831
+###  https://w3id.org/emmo/chemicalsubstance#substance_94af35ef_9e0d_4e4d_b794_ee0a14706831
 :substance_94af35ef_9e0d_4e4d_b794_ee0a14706831 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407821"@en ;
@@ -4255,7 +4255,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIISulfate"@en .
 
 
-###  http://emmo.info/substance#substance_9541345c_da1f_4f5b_bf89_09a4dfdb43cb
+###  https://w3id.org/emmo/chemicalsubstance#substance_9541345c_da1f_4f5b_bf89_09a4dfdb43cb
 :substance_9541345c_da1f_4f5b_bf89_09a4dfdb43cb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421215"@en ;
@@ -4268,7 +4268,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIISulfide"@en .
 
 
-###  http://emmo.info/substance#substance_95503d46_8343_4054_aa34_f0169ae0dbed
+###  https://w3id.org/emmo/chemicalsubstance#substance_95503d46_8343_4054_aa34_f0169ae0dbed
 :substance_95503d46_8343_4054_aa34_f0169ae0dbed rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q424250"@en ;
@@ -4281,7 +4281,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumSulfide"@en .
 
 
-###  http://emmo.info/substance#substance_957cb95c_00a1_4cf1_97b9_0d3b4f89f27e
+###  https://w3id.org/emmo/chemicalsubstance#substance_957cb95c_00a1_4cf1_97b9_0d3b4f89f27e
 :substance_957cb95c_00a1_4cf1_97b9_0d3b4f89f27e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q24237111"@en ;
@@ -4293,13 +4293,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIINitrite"@en .
 
 
-###  http://emmo.info/substance#substance_961f7671_8708_4ce3_9c7d_79444adba9c0
+###  https://w3id.org/emmo/chemicalsubstance#substance_961f7671_8708_4ce3_9c7d_79444adba9c0
 :substance_961f7671_8708_4ce3_9c7d_79444adba9c0 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 skos:prefLabel "Alcohol"@en .
 
 
-###  http://emmo.info/substance#substance_97439fbb_155f_433d_9edd_d510cd491f24
+###  https://w3id.org/emmo/chemicalsubstance#substance_97439fbb_155f_433d_9edd_d510cd491f24
 :substance_97439fbb_155f_433d_9edd_d510cd491f24 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/158503887" ;
@@ -4309,7 +4309,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumNickelPhosphate"@en .
 
 
-###  http://emmo.info/substance#substance_97932144_ab3b_4206_8238_ee8ea9b3327e
+###  https://w3id.org/emmo/chemicalsubstance#substance_97932144_ab3b_4206_8238_ee8ea9b3327e
 :substance_97932144_ab3b_4206_8238_ee8ea9b3327e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q15631940"@en ;
@@ -4322,7 +4322,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIIPerchlorate"@en .
 
 
-###  http://emmo.info/substance#substance_98c358bd_7326_4ce7_b46c_2a78f3fd10eb
+###  https://w3id.org/emmo/chemicalsubstance#substance_98c358bd_7326_4ce7_b46c_2a78f3fd10eb
 :substance_98c358bd_7326_4ce7_b46c_2a78f3fd10eb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q865952"@en ;
@@ -4337,7 +4337,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Diglyme"@en .
 
 
-###  http://emmo.info/substance#substance_994bfc80_9645_4178_9b1e_38513010206c
+###  https://w3id.org/emmo/chemicalsubstance#substance_994bfc80_9645_4178_9b1e_38513010206c
 :substance_994bfc80_9645_4178_9b1e_38513010206c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/166825" ;
@@ -4348,7 +4348,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumNitrite"@en .
 
 
-###  http://emmo.info/substance#substance_99789d57_25ea_4b0d_bebb_45012a85e9c4
+###  https://w3id.org/emmo/chemicalsubstance#substance_99789d57_25ea_4b0d_bebb_45012a85e9c4
 :substance_99789d57_25ea_4b0d_bebb_45012a85e9c4 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q206778"@en ;
@@ -4361,7 +4361,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SulfurousAcid"@en .
 
 
-###  http://emmo.info/substance#substance_99e61c41_9038_418a_b98c_ab225bd6bec1
+###  https://w3id.org/emmo/chemicalsubstance#substance_99e61c41_9038_418a_b98c_ab225bd6bec1
 :substance_99e61c41_9038_418a_b98c_ab225bd6bec1 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -4374,7 +4374,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Ruthenium"@en .
 
 
-###  http://emmo.info/substance#substance_9ad998c9_f5dd_48ff_af9f_b03d7b0211b4
+###  https://w3id.org/emmo/chemicalsubstance#substance_9ad998c9_f5dd_48ff_af9f_b03d7b0211b4
 :substance_9ad998c9_f5dd_48ff_af9f_b03d7b0211b4 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421781"@en ;
@@ -4387,7 +4387,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIIChloride"@en .
 
 
-###  http://emmo.info/substance#substance_9b92f5b9_a477_4267_bf68_769c995e6e83
+###  https://w3id.org/emmo/chemicalsubstance#substance_9b92f5b9_a477_4267_bf68_769c995e6e83
 :substance_9b92f5b9_a477_4267_bf68_769c995e6e83 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_b978912b_19ef_4d46_8c91_2e3578b12670 ;
@@ -4400,7 +4400,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Indium"@en .
 
 
-###  http://emmo.info/substance#substance_9bd78e1c_a4dc_41b6_8013_adb51df1ffdc
+###  https://w3id.org/emmo/chemicalsubstance#substance_9bd78e1c_a4dc_41b6_8013_adb51df1ffdc
 :substance_9bd78e1c_a4dc_41b6_8013_adb51df1ffdc rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -4413,7 +4413,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Zinc"@en .
 
 
-###  http://emmo.info/substance#substance_9c12a04b_1133_4ee0_ad24_26c835f12d1f
+###  https://w3id.org/emmo/chemicalsubstance#substance_9c12a04b_1133_4ee0_ad24_26c835f12d1f
 :substance_9c12a04b_1133_4ee0_ad24_26c835f12d1f rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_78400dc0_97b0_4d59_8ea6_30bb703f428c ;
@@ -4427,7 +4427,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Sulfur"@en .
 
 
-###  http://emmo.info/substance#substance_9c9ceee7_2470_4d05_89e7_28fb93108e38
+###  https://w3id.org/emmo/chemicalsubstance#substance_9c9ceee7_2470_4d05_89e7_28fb93108e38
 :substance_9c9ceee7_2470_4d05_89e7_28fb93108e38 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_b978912b_19ef_4d46_8c91_2e3578b12670 ;
@@ -4440,7 +4440,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Tin"@en .
 
 
-###  http://emmo.info/substance#substance_9d130518_2b84_435f_8632_039d43d2ef5d
+###  https://w3id.org/emmo/chemicalsubstance#substance_9d130518_2b84_435f_8632_039d43d2ef5d
 :substance_9d130518_2b84_435f_8632_039d43d2ef5d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q422597"@en ;
@@ -4452,7 +4452,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "HexanoicAcid"@en .
 
 
-###  http://emmo.info/substance#substance_9d25dbcc_5fc2_4281_ace2_335a1b5da266
+###  https://w3id.org/emmo/chemicalsubstance#substance_9d25dbcc_5fc2_4281_ace2_335a1b5da266
 :substance_9d25dbcc_5fc2_4281_ace2_335a1b5da266 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc9ba950_96c1_4ac2_a0e2_1c4f7f001b1d ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q410749"@en ;
@@ -4465,14 +4465,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIVOxide"@en .
 
 
-###  http://emmo.info/substance#substance_9d6b0e6b_b51f_40a8_bc9d_1418ea5356b1
+###  https://w3id.org/emmo/chemicalsubstance#substance_9d6b0e6b_b51f_40a8_bc9d_1418ea5356b1
 :substance_9d6b0e6b_b51f_40a8_bc9d_1418ea5356b1 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 skos:altLabel "Ca(BOB)2"@en ;
                                                 skos:prefLabel "CalciumBisoxalatoborate"@en .
 
 
-###  http://emmo.info/substance#substance_9d6b7dd4_6276_4e57_bdbb_228823821995
+###  https://w3id.org/emmo/chemicalsubstance#substance_9d6b7dd4_6276_4e57_bdbb_228823821995
 :substance_9d6b7dd4_6276_4e57_bdbb_228823821995 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72514132"@en ;
@@ -4483,7 +4483,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MethoxyTrimethylSilane"@en .
 
 
-###  http://emmo.info/substance#substance_9d7497bb_fe1b_4b9f_808b_f6df310dd900
+###  https://w3id.org/emmo/chemicalsubstance#substance_9d7497bb_fe1b_4b9f_808b_f6df310dd900
 :substance_9d7497bb_fe1b_4b9f_808b_f6df310dd900 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q288266"@en ;
@@ -4496,7 +4496,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumSulfate"@en .
 
 
-###  http://emmo.info/substance#substance_9da78aea_d436_40e2_a68f_c3dee32b825e
+###  https://w3id.org/emmo/chemicalsubstance#substance_9da78aea_d436_40e2_a68f_c3dee32b825e
 :substance_9da78aea_d436_40e2_a68f_c3dee32b825e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_6c0cc397_d8c4_4473_a09f_1e5de568e0dd ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q947047"@en ;
@@ -4509,7 +4509,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CarbonMonofluoride"@en .
 
 
-###  http://emmo.info/substance#substance_9db045a6_0104_4b2d_85ce_9610e99c7fc4
+###  https://w3id.org/emmo/chemicalsubstance#substance_9db045a6_0104_4b2d_85ce_9610e99c7fc4
 :substance_9db045a6_0104_4b2d_85ce_9610e99c7fc4 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q205374"@en ;
@@ -4522,7 +4522,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumFluoride"@en .
 
 
-###  http://emmo.info/substance#substance_9e25f281_5f69_4300_82a7_9025ea2061c4
+###  https://w3id.org/emmo/chemicalsubstance#substance_9e25f281_5f69_4300_82a7_9025ea2061c4
 :substance_9e25f281_5f69_4300_82a7_9025ea2061c4 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q423000"@en ;
@@ -4536,7 +4536,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Trichlorofluoromethane"@en .
 
 
-###  http://emmo.info/substance#substance_9f40a798_f293_487a_a263_fc703778ae25
+###  https://w3id.org/emmo/chemicalsubstance#substance_9f40a798_f293_487a_a263_fc703778ae25
 :substance_9f40a798_f293_487a_a263_fc703778ae25 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q55164806"@en ;
@@ -4548,7 +4548,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIITetrafluoroborate"@en .
 
 
-###  http://emmo.info/substance#substance_9fb92a20_082e_4d43_83d0_4b2aba8345ca
+###  https://w3id.org/emmo/chemicalsubstance#substance_9fb92a20_082e_4d43_83d0_4b2aba8345ca
 :substance_9fb92a20_082e_4d43_83d0_4b2aba8345ca rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q211891"@en ;
@@ -4561,7 +4561,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NitrousAcid"@en .
 
 
-###  http://emmo.info/substance#substance_a021f565_c3de_46b7_b46b_be4c7849e1ea
+###  https://w3id.org/emmo/chemicalsubstance#substance_a021f565_c3de_46b7_b46b_be4c7849e1ea
 :substance_a021f565_c3de_46b7_b46b_be4c7849e1ea rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q425450"@en ;
@@ -4574,7 +4574,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumCarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_a065f68b_99ed_4bdd_b568_13158ba1731f
+###  https://w3id.org/emmo/chemicalsubstance#substance_a065f68b_99ed_4bdd_b568_13158ba1731f
 :substance_a065f68b_99ed_4bdd_b568_13158ba1731f rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -4588,20 +4588,20 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Acetone"@en .
 
 
-###  http://emmo.info/substance#substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746
+###  https://w3id.org/emmo/chemicalsubstance#substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746
 :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_fc93282d_cb35_4bab_81a8_78689ae59e5f ;
                                                 skos:prefLabel "StrontiumSaltCompound"@en .
 
 
-###  http://emmo.info/substance#substance_a092c93d_1d03_4d74_b0d7_7ed51b0a3eca
+###  https://w3id.org/emmo/chemicalsubstance#substance_a092c93d_1d03_4d74_b0d7_7ed51b0a3eca
 :substance_a092c93d_1d03_4d74_b0d7_7ed51b0a3eca rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 skos:altLabel "a(DFOB)2"@en ;
                                                 skos:prefLabel "BariumDifluorooxalatoborate"@en .
 
 
-###  http://emmo.info/substance#substance_a16a1bae_7844_42fd_bb6d_979195d6c933
+###  https://w3id.org/emmo/chemicalsubstance#substance_a16a1bae_7844_42fd_bb6d_979195d6c933
 :substance_a16a1bae_7844_42fd_bb6d_979195d6c933 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_68e4028b_0ec6_46da_8d1c_d00c644e8c82 ;
@@ -4614,7 +4614,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Sodium"@en .
 
 
-###  http://emmo.info/substance#substance_a2b46543_4d0f_488a_b51a_7ed3a4149170
+###  https://w3id.org/emmo/chemicalsubstance#substance_a2b46543_4d0f_488a_b51a_7ed3a4149170
 :substance_a2b46543_4d0f_488a_b51a_7ed3a4149170 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_6411d319_81a0_40f3_8e4d_09784d1c7644 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q177342"@en ;
@@ -4627,7 +4627,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumOxide"@en .
 
 
-###  http://emmo.info/substance#substance_a36cbc8b_f4a8_45ef_99da_748d840f51d4
+###  https://w3id.org/emmo/chemicalsubstance#substance_a36cbc8b_f4a8_45ef_99da_748d840f51d4
 :substance_a36cbc8b_f4a8_45ef_99da_748d840f51d4 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -4640,13 +4640,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Rhenium"@en .
 
 
-###  http://emmo.info/substance#substance_a4a5b239_d88e_4e03_a763_0bf2a3dd0f47
+###  https://w3id.org/emmo/chemicalsubstance#substance_a4a5b239_d88e_4e03_a763_0bf2a3dd0f47
 :substance_a4a5b239_d88e_4e03_a763_0bf2a3dd0f47 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ;
                                                 skos:prefLabel "AlkalineEarthMetalElementalSubstance"@en .
 
 
-###  http://emmo.info/substance#substance_a4e68f0a_07b5_4899_b570_f3a70a07b5b3
+###  https://w3id.org/emmo/chemicalsubstance#substance_a4e68f0a_07b5_4899_b570_f3a70a07b5b3
 :substance_a4e68f0a_07b5_4899_b570_f3a70a07b5b3 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/86649651" ;
@@ -4657,13 +4657,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincHexafluorophosphate"@en .
 
 
-###  http://emmo.info/substance#substance_a639df56_1fb2_47f3_8069_c929b5a84b86
+###  https://w3id.org/emmo/chemicalsubstance#substance_a639df56_1fb2_47f3_8069_c929b5a84b86
 :substance_a639df56_1fb2_47f3_8069_c929b5a84b86 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "VandaiumOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_a67cda39_f3ac_4983_a93d_07a2067b5901
+###  https://w3id.org/emmo/chemicalsubstance#substance_a67cda39_f3ac_4983_a93d_07a2067b5901
 :substance_a67cda39_f3ac_4983_a93d_07a2067b5901 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/26286" ;
@@ -4674,7 +4674,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumTetrafluoroborate"@en .
 
 
-###  http://emmo.info/substance#substance_a6d037e0_233e_4fb2_ba36_2f5b9263a450
+###  https://w3id.org/emmo/chemicalsubstance#substance_a6d037e0_233e_4fb2_ba36_2f5b9263a450
 :substance_a6d037e0_233e_4fb2_ba36_2f5b9263a450 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -4688,7 +4688,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Tetrahydrofuran"@en .
 
 
-###  http://emmo.info/substance#substance_a6feec60_5fe7_4687_b427_3bf2ed06008d
+###  https://w3id.org/emmo/chemicalsubstance#substance_a6feec60_5fe7_4687_b427_3bf2ed06008d
 :substance_a6feec60_5fe7_4687_b427_3bf2ed06008d rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -4702,7 +4702,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Dichloromethane"@en .
 
 
-###  http://emmo.info/substance#substance_a84adfaa_e17e_4325_86d3_208d418e9956
+###  https://w3id.org/emmo/chemicalsubstance#substance_a84adfaa_e17e_4325_86d3_208d418e9956
 :substance_a84adfaa_e17e_4325_86d3_208d418e9956 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q184373"@en ;
@@ -4715,7 +4715,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumNitrate"@en .
 
 
-###  http://emmo.info/substance#substance_a8a48b58_d2ea_441c_b4ea_1b3ba65d9545
+###  https://w3id.org/emmo/chemicalsubstance#substance_a8a48b58_d2ea_441c_b4ea_1b3ba65d9545
 :substance_a8a48b58_d2ea_441c_b4ea_1b3ba65d9545 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q182329"@en ;
@@ -4728,13 +4728,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumNitrate"@en .
 
 
-###  http://emmo.info/substance#substance_a9218f8f_2e80_497e_b968_b4947cf21802
+###  https://w3id.org/emmo/chemicalsubstance#substance_a9218f8f_2e80_497e_b968_b4947cf21802
 :substance_a9218f8f_2e80_497e_b968_b4947cf21802 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ;
                                                 skos:prefLabel "ZirconiumOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_a95f6717_7edd_4901_9fbd_c0e39d95da65
+###  https://w3id.org/emmo/chemicalsubstance#substance_a95f6717_7edd_4901_9fbd_c0e39d95da65
 :substance_a95f6717_7edd_4901_9fbd_c0e39d95da65 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q28453483"@en ;
@@ -4747,13 +4747,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumChloride"@en .
 
 
-###  http://emmo.info/substance#substance_a9a6507f_9c61_44d3_bd86_f1ebf763e150
+###  https://w3id.org/emmo/chemicalsubstance#substance_a9a6507f_9c61_44d3_bd86_f1ebf763e150
 :substance_a9a6507f_9c61_44d3_bd86_f1ebf763e150 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ;
                                                 skos:prefLabel "MetalloidElementalSubstance"@en .
 
 
-###  http://emmo.info/substance#substance_aa7169ea_b61f_4b4c_a67b_50f2aea8bbf6
+###  https://w3id.org/emmo/chemicalsubstance#substance_aa7169ea_b61f_4b4c_a67b_50f2aea8bbf6
 :substance_aa7169ea_b61f_4b4c_a67b_50f2aea8bbf6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q410174"@en ;
@@ -4766,7 +4766,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumCarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_aa740290_2568_4b54_9d0f_2edc88e333ba
+###  https://w3id.org/emmo/chemicalsubstance#substance_aa740290_2568_4b54_9d0f_2edc88e333ba
 :substance_aa740290_2568_4b54_9d0f_2edc88e333ba rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f5b930f9_2f95_4268_993c_ff6b57ae7691 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2409"@en ;
@@ -4779,7 +4779,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "HydrogenChloride"@en .
 
 
-###  http://emmo.info/substance#substance_aa8e9cc4_5f66_4307_b1c8_26fac7653a90
+###  https://w3id.org/emmo/chemicalsubstance#substance_aa8e9cc4_5f66_4307_b1c8_26fac7653a90
 :substance_aa8e9cc4_5f66_4307_b1c8_26fac7653a90 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q3042400"@en ;
@@ -4792,13 +4792,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumIronPhosphate"@en .
 
 
-###  http://emmo.info/substance#substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4
+###  https://w3id.org/emmo/chemicalsubstance#substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4
 :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_edae7b22_461b_432b_b737_3c93feb69b0e ;
                                                 skos:prefLabel "AmmoniumSaltCompound"@en .
 
 
-###  http://emmo.info/substance#substance_ab34d4a3_a5c8_4318_9b7d_0608e2149398
+###  https://w3id.org/emmo/chemicalsubstance#substance_ab34d4a3_a5c8_4318_9b7d_0608e2149398
 :substance_ab34d4a3_a5c8_4318_9b7d_0608e2149398 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421133"@en ;
@@ -4811,14 +4811,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumAcetate"@en .
 
 
-###  http://emmo.info/substance#substance_ab3606c2_a1e3_4e40_b427_766c586b5f77
+###  https://w3id.org/emmo/chemicalsubstance#substance_ab3606c2_a1e3_4e40_b427_766c586b5f77
 :substance_ab3606c2_a1e3_4e40_b427_766c586b5f77 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 skos:altLabel "Sr(TFOB)2"@en ;
                                                 skos:prefLabel "StrontiumTrifluoromethanesulfonyloxalatoborate"@en .
 
 
-###  http://emmo.info/substance#substance_abeadd58_520a_49b1_b89a_f668f00cb7ff
+###  https://w3id.org/emmo/chemicalsubstance#substance_abeadd58_520a_49b1_b89a_f668f00cb7ff
 :substance_abeadd58_520a_49b1_b89a_f668f00cb7ff rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2546"@en ;
@@ -4831,7 +4831,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumBromide"@en .
 
 
-###  http://emmo.info/substance#substance_ac358c17_0cb7_4472_9c7a_fea07ae09e58
+###  https://w3id.org/emmo/chemicalsubstance#substance_ac358c17_0cb7_4472_9c7a_fea07ae09e58
 :substance_ac358c17_0cb7_4472_9c7a_fea07ae09e58 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_878a0e2f_12ba_484e_8197_75e57139d207 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2270"@en ;
@@ -4844,7 +4844,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Benzene"@en .
 
 
-###  http://emmo.info/substance#substance_acb8c003_6453_49d8_ad93_456cc99d5d10
+###  https://w3id.org/emmo/chemicalsubstance#substance_acb8c003_6453_49d8_ad93_456cc99d5d10
 :substance_acb8c003_6453_49d8_ad93_456cc99d5d10 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f5b930f9_2f95_4268_993c_ff6b57ae7691 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2447"@en ;
@@ -4857,7 +4857,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "HydrogenBromide"@en .
 
 
-###  http://emmo.info/substance#substance_acdb232f_8041_4e11_8a11_5db2d2baae4d
+###  https://w3id.org/emmo/chemicalsubstance#substance_acdb232f_8041_4e11_8a11_5db2d2baae4d
 :substance_acdb232f_8041_4e11_8a11_5db2d2baae4d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q3991823"@en ;
@@ -4870,7 +4870,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumTitanate"@en .
 
 
-###  http://emmo.info/substance#substance_ace24dd1_189a_4b0e_b110_7aad94309d15
+###  https://w3id.org/emmo/chemicalsubstance#substance_ace24dd1_189a_4b0e_b110_7aad94309d15
 :substance_ace24dd1_189a_4b0e_b110_7aad94309d15 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204639"@en ;
@@ -4883,14 +4883,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincAcetate"@en .
 
 
-###  http://emmo.info/substance#substance_ad1fe482_6d88_4207_b1e5_ef01b68bec97
+###  https://w3id.org/emmo/chemicalsubstance#substance_ad1fe482_6d88_4207_b1e5_ef01b68bec97
 :substance_ad1fe482_6d88_4207_b1e5_ef01b68bec97 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 skos:altLabel "Ba(BOB)2"@en ;
                                                 skos:prefLabel "BariumBisoxalatoborate"@en .
 
 
-###  http://emmo.info/substance#substance_ad5895fb_8fc3_42fc_8e9c_5c4723777624
+###  https://w3id.org/emmo/chemicalsubstance#substance_ad5895fb_8fc3_42fc_8e9c_5c4723777624
 :substance_ad5895fb_8fc3_42fc_8e9c_5c4723777624 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a639df56_1fb2_47f3_8069_c929b5a84b86 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1966236"@en ;
@@ -4903,7 +4903,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "VanadiumIIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_ada25a02_551d_4193_a944_57dda99ebb5b
+###  https://w3id.org/emmo/chemicalsubstance#substance_ada25a02_551d_4193_a944_57dda99ebb5b
 :substance_ada25a02_551d_4193_a944_57dda99ebb5b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409319"@en ;
@@ -4916,7 +4916,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumFluoride"@en .
 
 
-###  http://emmo.info/substance#substance_aef7d4bb_0b44_4974_84a0_e2729f5f2bef
+###  https://w3id.org/emmo/chemicalsubstance#substance_aef7d4bb_0b44_4974_84a0_e2729f5f2bef
 :substance_aef7d4bb_0b44_4974_84a0_e2729f5f2bef rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_88748886_9b7c_4df0_91eb_fe91ecc1b9cd ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407905"@en ;
@@ -4928,7 +4928,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ChromiumIIIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_af1422d5_f626_49e4_9302_cb94e6d5ff7b
+###  https://w3id.org/emmo/chemicalsubstance#substance_af1422d5_f626_49e4_9302_cb94e6d5ff7b
 :substance_af1422d5_f626_49e4_9302_cb94e6d5ff7b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q417080"@en ;
@@ -4941,7 +4941,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumFluoride"@en .
 
 
-###  http://emmo.info/substance#substance_af9dfae5_00b8_497a_a59a_83f0c5687734
+###  https://w3id.org/emmo/chemicalsubstance#substance_af9dfae5_00b8_497a_a59a_83f0c5687734
 :substance_af9dfae5_00b8_497a_a59a_83f0c5687734 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -4954,7 +4954,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Yttrium"@en .
 
 
-###  http://emmo.info/substance#substance_b01771a9_218a_4b01_b20f_4021cfa0b7d5
+###  https://w3id.org/emmo/chemicalsubstance#substance_b01771a9_218a_4b01_b20f_4021cfa0b7d5
 :substance_b01771a9_218a_4b01_b20f_4021cfa0b7d5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/22173729" ;
@@ -4964,13 +4964,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumManganesePhosphate"@en .
 
 
-###  http://emmo.info/substance#substance_b07a5287_67d1_4f4f_9640_e0146f713a6c
+###  https://w3id.org/emmo/chemicalsubstance#substance_b07a5287_67d1_4f4f_9640_e0146f713a6c
 :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_edae7b22_461b_432b_b737_3c93feb69b0e ;
                                                 skos:prefLabel "ZincSaltCompound"@en .
 
 
-###  http://emmo.info/substance#substance_b0948006_869b_4426_b2b7_30b5c5112e3e
+###  https://w3id.org/emmo/chemicalsubstance#substance_b0948006_869b_4426_b2b7_30b5c5112e3e
 :substance_b0948006_869b_4426_b2b7_30b5c5112e3e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q24629264"@en ;
@@ -4983,7 +4983,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIIPerchlorate"@en .
 
 
-###  http://emmo.info/substance#substance_b0abf2a1_540e_42fc_b3cf_f5a8a43e591d
+###  https://w3id.org/emmo/chemicalsubstance#substance_b0abf2a1_540e_42fc_b3cf_f5a8a43e591d
 :substance_b0abf2a1_540e_42fc_b3cf_f5a8a43e591d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q47512"@en ;
@@ -4996,7 +4996,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AceticAcid"@en .
 
 
-###  http://emmo.info/substance#substance_b1c9078e_f001_4a8a_a56d_2c6444a18201
+###  https://w3id.org/emmo/chemicalsubstance#substance_b1c9078e_f001_4a8a_a56d_2c6444a18201
 :substance_b1c9078e_f001_4a8a_a56d_2c6444a18201 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q265414"@en ;
@@ -5009,7 +5009,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumChloride"@en .
 
 
-###  http://emmo.info/substance#substance_b1cf27b3_b657_430e_80e9_c506cc522cbb
+###  https://w3id.org/emmo/chemicalsubstance#substance_b1cf27b3_b657_430e_80e9_c506cc522cbb
 :substance_b1cf27b3_b657_430e_80e9_c506cc522cbb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q413552"@en ;
@@ -5022,7 +5022,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "GlyoxylicAcid"@en .
 
 
-###  http://emmo.info/substance#substance_b258c23a_748e_4f92_9d55_354b92c298df
+###  https://w3id.org/emmo/chemicalsubstance#substance_b258c23a_748e_4f92_9d55_354b92c298df
 :substance_b258c23a_748e_4f92_9d55_354b92c298df rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q159683"@en ;
@@ -5034,7 +5034,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CitricAcid"@en .
 
 
-###  http://emmo.info/substance#substance_b3130004_ad93_4cff_84b5_1f8d77b97ecb
+###  https://w3id.org/emmo/chemicalsubstance#substance_b3130004_ad93_4cff_84b5_1f8d77b97ecb
 :substance_b3130004_ad93_4cff_84b5_1f8d77b97ecb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421083"@en ;
@@ -5047,13 +5047,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumNitrate"@en .
 
 
-###  http://emmo.info/substance#substance_b325bdd7_0adf_4522_a4ef_20cd6929e094
+###  https://w3id.org/emmo/chemicalsubstance#substance_b325bdd7_0adf_4522_a4ef_20cd6929e094
 :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 skos:prefLabel "OrganicAcidCompound"@en .
 
 
-###  http://emmo.info/substance#substance_b3708b26_f2dc_4a68_97c3_fced02c8d0e2
+###  https://w3id.org/emmo/chemicalsubstance#substance_b3708b26_f2dc_4a68_97c3_fced02c8d0e2
 :substance_b3708b26_f2dc_4a68_97c3_fced02c8d0e2 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -5067,7 +5067,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Acetonitrile"@en .
 
 
-###  http://emmo.info/substance#substance_b3815a7f_f64a_48f6_b0ce_d0032578c699
+###  https://w3id.org/emmo/chemicalsubstance#substance_b3815a7f_f64a_48f6_b0ce_d0032578c699
 :substance_b3815a7f_f64a_48f6_b0ce_d0032578c699 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -5080,7 +5080,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Gold"@en .
 
 
-###  http://emmo.info/substance#substance_b403f5ab_25b5_4721_983d_2792a7624972
+###  https://w3id.org/emmo/chemicalsubstance#substance_b403f5ab_25b5_4721_983d_2792a7624972
 :substance_b403f5ab_25b5_4721_983d_2792a7624972 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_878a0e2f_12ba_484e_8197_75e57139d207 ,
                                                                 :substance_961f7671_8708_4ce3_9c7d_79444adba9c0 ;
@@ -5094,7 +5094,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Ethanol"@en .
 
 
-###  http://emmo.info/substance#substance_b468a310_e399_40e3_b9b9_6c7d90dbd07b
+###  https://w3id.org/emmo/chemicalsubstance#substance_b468a310_e399_40e3_b9b9_6c7d90dbd07b
 :substance_b468a310_e399_40e3_b9b9_6c7d90dbd07b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4ca80d73_ea14_4a81_9df1_8a16ecbfd041 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q417022"@en ;
@@ -5107,13 +5107,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "RutheniumIVOxide"@en .
 
 
-###  http://emmo.info/substance#substance_b474f792_011e_4c9a_8dee_b99d6459cd66
+###  https://w3id.org/emmo/chemicalsubstance#substance_b474f792_011e_4c9a_8dee_b99d6459cd66
 :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ;
                                                 skos:prefLabel "TransitionMetalOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_b496f6dd_0476_43e7_a1a9_7e025afce627
+###  https://w3id.org/emmo/chemicalsubstance#substance_b496f6dd_0476_43e7_a1a9_7e025afce627
 :substance_b496f6dd_0476_43e7_a1a9_7e025afce627 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -5126,7 +5126,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Manganese"@en .
 
 
-###  http://emmo.info/substance#substance_b593b5dd_7957_4b85_856a_dd59775210b6
+###  https://w3id.org/emmo/chemicalsubstance#substance_b593b5dd_7957_4b85_856a_dd59775210b6
 :substance_b593b5dd_7957_4b85_856a_dd59775210b6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407927"@en ;
@@ -5139,7 +5139,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "DimethylSulfoxide"@en .
 
 
-###  http://emmo.info/substance#substance_b5ad0a60_44cf_40b2_880d_92a195a65859
+###  https://w3id.org/emmo/chemicalsubstance#substance_b5ad0a60_44cf_40b2_880d_92a195a65859
 :substance_b5ad0a60_44cf_40b2_880d_92a195a65859 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -5152,14 +5152,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Scandium"@en .
 
 
-###  http://emmo.info/substance#substance_b5d8ff31_cc34_4f22_bfcc_7ffbe69c0b26
+###  https://w3id.org/emmo/chemicalsubstance#substance_b5d8ff31_cc34_4f22_bfcc_7ffbe69c0b26
 :substance_b5d8ff31_cc34_4f22_bfcc_7ffbe69c0b26 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 skos:altLabel "Sr(BOB)2"@en ;
                                                 skos:prefLabel "StrontiumBisoxalatoborate"@en .
 
 
-###  http://emmo.info/substance#substance_b67e85ce_a540_43bd_a3b5_0a5fe341194e
+###  https://w3id.org/emmo/chemicalsubstance#substance_b67e85ce_a540_43bd_a3b5_0a5fe341194e
 :substance_b67e85ce_a540_43bd_a3b5_0a5fe341194e rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -5172,7 +5172,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Vanadium"@en .
 
 
-###  http://emmo.info/substance#substance_b6ec6818_6d76_41b7_83d4_92b8e2363b90
+###  https://w3id.org/emmo/chemicalsubstance#substance_b6ec6818_6d76_41b7_83d4_92b8e2363b90
 :substance_b6ec6818_6d76_41b7_83d4_92b8e2363b90 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q415471"@en ;
@@ -5185,7 +5185,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumNitrate"@en .
 
 
-###  http://emmo.info/substance#substance_b6ecabf9_14a4_4808_a139_55329e70ad42
+###  https://w3id.org/emmo/chemicalsubstance#substance_b6ecabf9_14a4_4808_a139_55329e70ad42
 :substance_b6ecabf9_14a4_4808_a139_55329e70ad42 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q416271"@en ;
@@ -5198,7 +5198,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Dimethoxyethane"@en .
 
 
-###  http://emmo.info/substance#substance_b72166c7_eb2a_44b0_8af4_3a2042148157
+###  https://w3id.org/emmo/chemicalsubstance#substance_b72166c7_eb2a_44b0_8af4_3a2042148157
 :substance_b72166c7_eb2a_44b0_8af4_3a2042148157 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q412538"@en ;
@@ -5211,7 +5211,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumIodide"@en .
 
 
-###  http://emmo.info/substance#substance_b7c3fc7f_a189_46ff_bd3d_21f899507e94
+###  https://w3id.org/emmo/chemicalsubstance#substance_b7c3fc7f_a189_46ff_bd3d_21f899507e94
 :substance_b7c3fc7f_a189_46ff_bd3d_21f899507e94 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q6731399"@en ;
@@ -5224,7 +5224,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumPhosphate"@en .
 
 
-###  http://emmo.info/substance#substance_b7f0a973_a394_409a_8752_f920b001c2d7
+###  https://w3id.org/emmo/chemicalsubstance#substance_b7f0a973_a394_409a_8752_f920b001c2d7
 :substance_b7f0a973_a394_409a_8752_f920b001c2d7 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4202651"@en ;
@@ -5236,7 +5236,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIodide"@en .
 
 
-###  http://emmo.info/substance#substance_b8b79435_2d26_4784_8c36_385ec8ef9661
+###  https://w3id.org/emmo/chemicalsubstance#substance_b8b79435_2d26_4784_8c36_385ec8ef9661
 :substance_b8b79435_2d26_4784_8c36_385ec8ef9661 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q3998748"@en ;
@@ -5249,7 +5249,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumTriflate"@en .
 
 
-###  http://emmo.info/substance#substance_b8baff0d_7163_4ef1_ac3b_7694b59e500a
+###  https://w3id.org/emmo/chemicalsubstance#substance_b8baff0d_7163_4ef1_ac3b_7694b59e500a
 :substance_b8baff0d_7163_4ef1_ac3b_7694b59e500a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q420616"@en ;
@@ -5263,19 +5263,19 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "DiethylCarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_b8c65e71_05de_4f07_acd8_a16938b550fd
+###  https://w3id.org/emmo/chemicalsubstance#substance_b8c65e71_05de_4f07_acd8_a16938b550fd
 :substance_b8c65e71_05de_4f07_acd8_a16938b550fd rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "NickelOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_b978912b_19ef_4d46_8c91_2e3578b12670
+###  https://w3id.org/emmo/chemicalsubstance#substance_b978912b_19ef_4d46_8c91_2e3578b12670
 :substance_b978912b_19ef_4d46_8c91_2e3578b12670 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ;
                                                 skos:prefLabel "PostTransitionMetalElementalSubstance"@en .
 
 
-###  http://emmo.info/substance#substance_b9d12a93_8bcc_4da1_ab17_3c5bbe25ba5f
+###  https://w3id.org/emmo/chemicalsubstance#substance_b9d12a93_8bcc_4da1_ab17_3c5bbe25ba5f
 :substance_b9d12a93_8bcc_4da1_ab17_3c5bbe25ba5f rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_8e5448fc_1916_4afb_9fd9_2489797f6922 ;
@@ -5289,7 +5289,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelHydroxide"@en .
 
 
-###  http://emmo.info/substance#substance_b9d9fc15_544b_4b9f_b39c_250b90c379b7
+###  https://w3id.org/emmo/chemicalsubstance#substance_b9d9fc15_544b_4b9f_b39c_250b90c379b7
 :substance_b9d9fc15_544b_4b9f_b39c_250b90c379b7 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q27273582"@en ;
@@ -5300,7 +5300,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "DimethoxyDimethylSilane"@en .
 
 
-###  http://emmo.info/substance#substance_ba4394f5_21c3_4ae1_96a4_3c9e2138b7e0
+###  https://w3id.org/emmo/chemicalsubstance#substance_ba4394f5_21c3_4ae1_96a4_3c9e2138b7e0
 :substance_ba4394f5_21c3_4ae1_96a4_3c9e2138b7e0 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q416265"@en ;
@@ -5313,7 +5313,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumIodide"@en .
 
 
-###  http://emmo.info/substance#substance_badb80db_ae6e_4048_a720_e26229995443
+###  https://w3id.org/emmo/chemicalsubstance#substance_badb80db_ae6e_4048_a720_e26229995443
 :substance_badb80db_ae6e_4048_a720_e26229995443 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q376994"@en ;
@@ -5326,7 +5326,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Pseudocumeme"@en .
 
 
-###  http://emmo.info/substance#substance_bafc6512_126d_4d9a_9c08_2b210317e77f
+###  https://w3id.org/emmo/chemicalsubstance#substance_bafc6512_126d_4d9a_9c08_2b210317e77f
 :substance_bafc6512_126d_4d9a_9c08_2b210317e77f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/23515" ;
@@ -5338,7 +5338,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Hexafluoroarsenate"@en .
 
 
-###  http://emmo.info/substance#substance_bb20bdea_343c_4911_8c45_37fc1077d22f
+###  https://w3id.org/emmo/chemicalsubstance#substance_bb20bdea_343c_4911_8c45_37fc1077d22f
 :substance_bb20bdea_343c_4911_8c45_37fc1077d22f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q15632858"@en ;
@@ -5350,7 +5350,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "EthylMethylCarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_bb42264f_9049_47a5_ac87_a363fa8ae503
+###  https://w3id.org/emmo/chemicalsubstance#substance_bb42264f_9049_47a5_ac87_a363fa8ae503
 :substance_bb42264f_9049_47a5_ac87_a363fa8ae503 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/6096284" ;
@@ -5361,7 +5361,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumTetrafluoroborate"@en .
 
 
-###  http://emmo.info/substance#substance_bb66572a_387d_4384_92d8_fdf71918dc45
+###  https://w3id.org/emmo/chemicalsubstance#substance_bb66572a_387d_4384_92d8_fdf71918dc45
 :substance_bb66572a_387d_4384_92d8_fdf71918dc45 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2823289"@en ;
@@ -5373,7 +5373,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MesoxalicAcid"@en .
 
 
-###  http://emmo.info/substance#substance_bbfa82dc_68a0_4d0b_a3f0_735cbbc19cf2
+###  https://w3id.org/emmo/chemicalsubstance#substance_bbfa82dc_68a0_4d0b_a3f0_735cbbc19cf2
 :substance_bbfa82dc_68a0_4d0b_a3f0_735cbbc19cf2 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -5386,13 +5386,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Iridium"@en .
 
 
-###  http://emmo.info/substance#substance_bc76f17d_931a_4728_9663_9f8ed208d5e4
+###  https://w3id.org/emmo/chemicalsubstance#substance_bc76f17d_931a_4728_9663_9f8ed208d5e4
 :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_015116fe_94ca_4be5_9d14_9d9457a47a72 ;
                                                 skos:prefLabel "CobaltSaltCompound"@en .
 
 
-###  http://emmo.info/substance#substance_bc7f9905_0c1d_4911_9155_d31e96dceb55
+###  https://w3id.org/emmo/chemicalsubstance#substance_bc7f9905_0c1d_4911_9155_d31e96dceb55
 :substance_bc7f9905_0c1d_4911_9155_d31e96dceb55 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_cac14194_2d5f_4fe6_b794_a9319f6d76ee ;
@@ -5405,13 +5405,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Radon"@en .
 
 
-###  http://emmo.info/substance#substance_bc9ba950_96c1_4ac2_a0e2_1c4f7f001b1d
+###  https://w3id.org/emmo/chemicalsubstance#substance_bc9ba950_96c1_4ac2_a0e2_1c4f7f001b1d
 :substance_bc9ba950_96c1_4ac2_a0e2_1c4f7f001b1d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "LeadOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_bd6a2a7a_d9d6_453e_a1d8_2048e884d36e
+###  https://w3id.org/emmo/chemicalsubstance#substance_bd6a2a7a_d9d6_453e_a1d8_2048e884d36e
 :substance_bd6a2a7a_d9d6_453e_a1d8_2048e884d36e rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_78400dc0_97b0_4d59_8ea6_30bb703f428c ;
@@ -5425,7 +5425,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Bromine"@en .
 
 
-###  http://emmo.info/substance#substance_bd75a1b8_f5fe_4676_a42c_6192c3a70b22
+###  https://w3id.org/emmo/chemicalsubstance#substance_bd75a1b8_f5fe_4676_a42c_6192c3a70b22
 :substance_bd75a1b8_f5fe_4676_a42c_6192c3a70b22 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421854"@en ;
@@ -5438,7 +5438,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIIAcetate"@en .
 
 
-###  http://emmo.info/substance#substance_bdeefc5a_a32a_4354_a7a3_2a842784a937
+###  https://w3id.org/emmo/chemicalsubstance#substance_bdeefc5a_a32a_4354_a7a3_2a842784a937
 :substance_bdeefc5a_a32a_4354_a7a3_2a842784a937 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409393"@en ;
@@ -5451,7 +5451,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIISulfate"@en .
 
 
-###  http://emmo.info/substance#substance_be030e60_3df6_4147_ba07_c99618bed3fb
+###  https://w3id.org/emmo/chemicalsubstance#substance_be030e60_3df6_4147_ba07_c99618bed3fb
 :substance_be030e60_3df6_4147_ba07_c99618bed3fb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204783"@en ;
@@ -5464,7 +5464,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincFluoride"@en .
 
 
-###  http://emmo.info/substance#substance_be34d464_0eb9_4861_8998_5cce0f1e2979
+###  https://w3id.org/emmo/chemicalsubstance#substance_be34d464_0eb9_4861_8998_5cce0f1e2979
 :substance_be34d464_0eb9_4861_8998_5cce0f1e2979 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q412874"@en ;
@@ -5477,7 +5477,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumSulfide"@en .
 
 
-###  http://emmo.info/substance#substance_bea2f4f7_04b9_48db_aae3_a04832c0f58d
+###  https://w3id.org/emmo/chemicalsubstance#substance_bea2f4f7_04b9_48db_aae3_a04832c0f58d
 :substance_bea2f4f7_04b9_48db_aae3_a04832c0f58d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q15634038"@en ;
@@ -5490,7 +5490,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIIPhosphate"@en .
 
 
-###  http://emmo.info/substance#substance_beb2ddc0_17f9_430d_b271_31fc2d6ca1a1
+###  https://w3id.org/emmo/chemicalsubstance#substance_beb2ddc0_17f9_430d_b271_31fc2d6ca1a1
 :substance_beb2ddc0_17f9_430d_b271_31fc2d6ca1a1 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_f5b930f9_2f95_4268_993c_ff6b57ae7691 ;
@@ -5504,13 +5504,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SulfuricAcid"@en .
 
 
-###  http://emmo.info/substance#substance_bed1a22c_8b61_467a_86a0_d24c7b910653
+###  https://w3id.org/emmo/chemicalsubstance#substance_bed1a22c_8b61_467a_86a0_d24c7b910653
 :substance_bed1a22c_8b61_467a_86a0_d24c7b910653 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7beec353_bad9_46fc_a035_a76b131fb32b ;
                                                 skos:prefLabel "StrongBaseCompound"@en .
 
 
-###  http://emmo.info/substance#substance_bf30b2d9_adc4_424a_83b0_927d33b2cbad
+###  https://w3id.org/emmo/chemicalsubstance#substance_bf30b2d9_adc4_424a_83b0_927d33b2cbad
 :substance_bf30b2d9_adc4_424a_83b0_927d33b2cbad rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_6c0cc397_d8c4_4473_a09f_1e5de568e0dd ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q169917"@en ;
@@ -5522,7 +5522,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Graphene"@en .
 
 
-###  http://emmo.info/substance#substance_bf339a87_3d85_48bf_b10e_dcf482af3b71
+###  https://w3id.org/emmo/chemicalsubstance#substance_bf339a87_3d85_48bf_b10e_dcf482af3b71
 :substance_bf339a87_3d85_48bf_b10e_dcf482af3b71 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204714"@en ;
@@ -5535,7 +5535,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincChloride"@en .
 
 
-###  http://emmo.info/substance#substance_bf4787df_bf4f_4ebd_bd0b_17f982591761
+###  https://w3id.org/emmo/chemicalsubstance#substance_bf4787df_bf4f_4ebd_bd0b_17f982591761
 :substance_bf4787df_bf4f_4ebd_bd0b_17f982591761 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q528995"@en ;
@@ -5548,7 +5548,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Thiourea"@en .
 
 
-###  http://emmo.info/substance#substance_bf77edae_ea79_45fb_9ed1_5b8a24665cca
+###  https://w3id.org/emmo/chemicalsubstance#substance_bf77edae_ea79_45fb_9ed1_5b8a24665cca
 :substance_bf77edae_ea79_45fb_9ed1_5b8a24665cca rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q15768"@en ;
@@ -5561,7 +5561,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumBromide"@en .
 
 
-###  http://emmo.info/substance#substance_bf83d174_677d_45ec_ab8b_fef7109ad91c
+###  https://w3id.org/emmo/chemicalsubstance#substance_bf83d174_677d_45ec_ab8b_fef7109ad91c
 :substance_bf83d174_677d_45ec_ab8b_fef7109ad91c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0111fe83_2d6c_4df0_9fd3_500ddda7242c ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/16702109" ;
@@ -5572,7 +5572,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "GalliumIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_c0adf859_7694_440e_8c65_cb2b6b67f88b
+###  https://w3id.org/emmo/chemicalsubstance#substance_c0adf859_7694_440e_8c65_cb2b6b67f88b
 :substance_c0adf859_7694_440e_8c65_cb2b6b67f88b rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a4a5b239_d88e_4e03_a763_0bf2a3dd0f47 ;
@@ -5586,14 +5586,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Radium"@en .
 
 
-###  http://emmo.info/substance#substance_c0ed3eca_64ef_4e69_a415_3e5f76ca27b6
+###  https://w3id.org/emmo/chemicalsubstance#substance_c0ed3eca_64ef_4e69_a415_3e5f76ca27b6
 :substance_c0ed3eca_64ef_4e69_a415_3e5f76ca27b6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 skos:altLabel "Mg(BOP)2"@en ;
                                                 skos:prefLabel "MagnesiumBisoxalatophosphate"@en .
 
 
-###  http://emmo.info/substance#substance_c0f3ef19_325e_469d_95d4_2d7568796163
+###  https://w3id.org/emmo/chemicalsubstance#substance_c0f3ef19_325e_469d_95d4_2d7568796163
 :substance_c0f3ef19_325e_469d_95d4_2d7568796163 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_52da9471_9979_44b0_a415_63c72110fd43 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q196680"@en ;
@@ -5606,7 +5606,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IronIIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_c109ca45_08c7_4436_a818_a9c575785e2f
+###  https://w3id.org/emmo/chemicalsubstance#substance_c109ca45_08c7_4436_a818_a9c575785e2f
 :substance_c109ca45_08c7_4436_a818_a9c575785e2f rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_68e4028b_0ec6_46da_8d1c_d00c644e8c82 ;
@@ -5620,13 +5620,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Lithium"@en .
 
 
-###  http://emmo.info/substance#substance_c12c3203_9d18_4a69_8a10_25b100ff48c8
+###  https://w3id.org/emmo/chemicalsubstance#substance_c12c3203_9d18_4a69_8a10_25b100ff48c8
 :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_fc93282d_cb35_4bab_81a8_78689ae59e5f ;
                                                 skos:prefLabel "CalciumSaltCompound"@en .
 
 
-###  http://emmo.info/substance#substance_c1b3e4ab_f4c2_443e_9143_99e7c3654448
+###  https://w3id.org/emmo/chemicalsubstance#substance_c1b3e4ab_f4c2_443e_9143_99e7c3654448
 :substance_c1b3e4ab_f4c2_443e_9143_99e7c3654448 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4ad18bbe_6478_4009_8f80_b669a6ae3f7a ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4332822"@en ;
@@ -5638,7 +5638,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IridiumIIIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_c28a0967_ed23_48cc_a14e_a651d75a19db
+###  https://w3id.org/emmo/chemicalsubstance#substance_c28a0967_ed23_48cc_a14e_a651d75a19db
 :substance_c28a0967_ed23_48cc_a14e_a651d75a19db rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q81988484"@en ;
@@ -5650,7 +5650,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumNickelOxide"@en .
 
 
-###  http://emmo.info/substance#substance_c3474f9a_87bd_4b73_9398_6e1ccbf133af
+###  https://w3id.org/emmo/chemicalsubstance#substance_c3474f9a_87bd_4b73_9398_6e1ccbf133af
 :substance_c3474f9a_87bd_4b73_9398_6e1ccbf133af rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q191831"@en ;
@@ -5663,7 +5663,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumSulfate"@en .
 
 
-###  http://emmo.info/substance#substance_c38dc7a0_bbeb_43d8_8fdd_15f6f977332a
+###  https://w3id.org/emmo/chemicalsubstance#substance_c38dc7a0_bbeb_43d8_8fdd_15f6f977332a
 :substance_c38dc7a0_bbeb_43d8_8fdd_15f6f977332a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q408920"@en ;
@@ -5676,7 +5676,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumSulfide"@en .
 
 
-###  http://emmo.info/substance#substance_c4a7d7bd_497e_457e_b858_ff73254266d0
+###  https://w3id.org/emmo/chemicalsubstance#substance_c4a7d7bd_497e_457e_b858_ff73254266d0
 :substance_c4a7d7bd_497e_457e_b858_ff73254266d0 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q416254"@en ;
@@ -5690,7 +5690,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "DimethylCarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_c4d116ed_258d_482c_8632_5c8229e7b245
+###  https://w3id.org/emmo/chemicalsubstance#substance_c4d116ed_258d_482c_8632_5c8229e7b245
 :substance_c4d116ed_258d_482c_8632_5c8229e7b245 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q161249"@en ;
@@ -5702,7 +5702,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LacticAcid"@en .
 
 
-###  http://emmo.info/substance#substance_c505a8a2_feb3_4a8e_92fa_e2fee3cd776b
+###  https://w3id.org/emmo/chemicalsubstance#substance_c505a8a2_feb3_4a8e_92fa_e2fee3cd776b
 :substance_c505a8a2_feb3_4a8e_92fa_e2fee3cd776b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/87861747" ;
@@ -5713,7 +5713,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIITriflate"@en .
 
 
-###  http://emmo.info/substance#substance_c5582dae_ccff_4fbe_adaa_078091054640
+###  https://w3id.org/emmo/chemicalsubstance#substance_c5582dae_ccff_4fbe_adaa_078091054640
 :substance_c5582dae_ccff_4fbe_adaa_078091054640 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/160476084" ;
@@ -5722,14 +5722,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumIronPhosphate"@en .
 
 
-###  http://emmo.info/substance#substance_c581b064_f357_4378_96bc_dcb2c72013f8
+###  https://w3id.org/emmo/chemicalsubstance#substance_c581b064_f357_4378_96bc_dcb2c72013f8
 :substance_c581b064_f357_4378_96bc_dcb2c72013f8 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 skos:altLabel "Mg(BF4)2"@en ;
                                                 skos:prefLabel "MagnesiumTetrafluoroborate"@en .
 
 
-###  http://emmo.info/substance#substance_c5adcfc9_d0f3_40d5_8aa0_6836d3c3b374
+###  https://w3id.org/emmo/chemicalsubstance#substance_c5adcfc9_d0f3_40d5_8aa0_6836d3c3b374
 :substance_c5adcfc9_d0f3_40d5_8aa0_6836d3c3b374 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q414659"@en ;
@@ -5742,7 +5742,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIICarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_c5cff8c2_581e_4341_a3e6_8ba8c8ce2d2b
+###  https://w3id.org/emmo/chemicalsubstance#substance_c5cff8c2_581e_4341_a3e6_8ba8c8ce2d2b
 :substance_c5cff8c2_581e_4341_a3e6_8ba8c8ce2d2b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7e716191_b301_4d63_bb6b_93323ffe51bf ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q146174"@en ;
@@ -5751,14 +5751,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Polypropylene"@en .
 
 
-###  http://emmo.info/substance#substance_c5e6b38b_af73_4664_911b_4a6ecc8f2e3f
+###  https://w3id.org/emmo/chemicalsubstance#substance_c5e6b38b_af73_4664_911b_4a6ecc8f2e3f
 :substance_c5e6b38b_af73_4664_911b_4a6ecc8f2e3f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 skos:altLabel "Sr(BOP)2"@en ;
                                                 skos:prefLabel "StrontiumBisoxalatophosphate"@en .
 
 
-###  http://emmo.info/substance#substance_c6c667a8_90ab_4b23_8441_5e7d0eb7dc31
+###  https://w3id.org/emmo/chemicalsubstance#substance_c6c667a8_90ab_4b23_8441_5e7d0eb7dc31
 :substance_c6c667a8_90ab_4b23_8441_5e7d0eb7dc31 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q11129316"@en ;
@@ -5770,13 +5770,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumTetrafluoroborate"@en .
 
 
-###  http://emmo.info/substance#substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f
+###  https://w3id.org/emmo/chemicalsubstance#substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f
 :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_6c490298_2ce8_41e1_ac37_4b44faff2d44 ;
                                                 skos:prefLabel "PotassiumSaltCompound"@en .
 
 
-###  http://emmo.info/substance#substance_c7282858_dabe_4cbc_96f9_d5d844986e4f
+###  https://w3id.org/emmo/chemicalsubstance#substance_c7282858_dabe_4cbc_96f9_d5d844986e4f
 :substance_c7282858_dabe_4cbc_96f9_d5d844986e4f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421106"@en ;
@@ -5789,7 +5789,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumSulfate"@en .
 
 
-###  http://emmo.info/substance#substance_c728b6b9_449a_45ff_b5ae_6b7968708f0d
+###  https://w3id.org/emmo/chemicalsubstance#substance_c728b6b9_449a_45ff_b5ae_6b7968708f0d
 :substance_c728b6b9_449a_45ff_b5ae_6b7968708f0d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4154e6b6_8e3c_4173_91aa_e8ba403bde85 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1311146"@en ;
@@ -5802,7 +5802,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IronDisulfide"@en .
 
 
-###  http://emmo.info/substance#substance_c77f3c17_6eec_4875_92fc_50db5212ea86
+###  https://w3id.org/emmo/chemicalsubstance#substance_c77f3c17_6eec_4875_92fc_50db5212ea86
 :substance_c77f3c17_6eec_4875_92fc_50db5212ea86 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_878a0e2f_12ba_484e_8197_75e57139d207 ,
                                                                 :substance_961f7671_8708_4ce3_9c7d_79444adba9c0 ;
@@ -5816,7 +5816,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NPropanol"@en .
 
 
-###  http://emmo.info/substance#substance_c7a8d82c_de8f_461f_b86d_62e79ff27e6b
+###  https://w3id.org/emmo/chemicalsubstance#substance_c7a8d82c_de8f_461f_b86d_62e79ff27e6b
 :substance_c7a8d82c_de8f_461f_b86d_62e79ff27e6b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c7bab57c_23c4_41d7_b2dc_497683fc82db ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q3488660"@en ;
@@ -5829,7 +5829,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "RhodiumIIIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_c7b881c4_6149_488c_bd47_5e8ccfdd071e
+###  https://w3id.org/emmo/chemicalsubstance#substance_c7b881c4_6149_488c_bd47_5e8ccfdd071e
 :substance_c7b881c4_6149_488c_bd47_5e8ccfdd071e rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a4a5b239_d88e_4e03_a763_0bf2a3dd0f47 ;
@@ -5843,13 +5843,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Beryllium"@en .
 
 
-###  http://emmo.info/substance#substance_c7bab57c_23c4_41d7_b2dc_497683fc82db
+###  https://w3id.org/emmo/chemicalsubstance#substance_c7bab57c_23c4_41d7_b2dc_497683fc82db
 :substance_c7bab57c_23c4_41d7_b2dc_497683fc82db rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "RhodiumOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_c9141094_0700_41ec_8373_4fc52b2f1615
+###  https://w3id.org/emmo/chemicalsubstance#substance_c9141094_0700_41ec_8373_4fc52b2f1615
 :substance_c9141094_0700_41ec_8373_4fc52b2f1615 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bed1a22c_8b61_467a_86a0_d24c7b910653 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407605"@en ;
@@ -5862,7 +5862,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumHydroxide"@en .
 
 
-###  http://emmo.info/substance#substance_ca0f0da1_70d2_46ec_a1bb_0f0662ff4191
+###  https://w3id.org/emmo/chemicalsubstance#substance_ca0f0da1_70d2_46ec_a1bb_0f0662ff4191
 :substance_ca0f0da1_70d2_46ec_a1bb_0f0662ff4191 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2331023"@en ;
@@ -5875,7 +5875,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIISulfate"@en .
 
 
-###  http://emmo.info/substance#substance_cac01669_51a9_410f_9a12_4bb0e19296f6
+###  https://w3id.org/emmo/chemicalsubstance#substance_cac01669_51a9_410f_9a12_4bb0e19296f6
 :substance_cac01669_51a9_410f_9a12_4bb0e19296f6 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a9a6507f_9c61_44d3_bd86_f1ebf763e150 ;
@@ -5889,13 +5889,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Boron"@en .
 
 
-###  http://emmo.info/substance#substance_cac14194_2d5f_4fe6_b794_a9319f6d76ee
+###  https://w3id.org/emmo/chemicalsubstance#substance_cac14194_2d5f_4fe6_b794_a9319f6d76ee
 :substance_cac14194_2d5f_4fe6_b794_a9319f6d76ee rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ;
                                                 skos:prefLabel "NobleGasElementalSubstance"@en .
 
 
-###  http://emmo.info/substance#substance_cb320164_c9d7_48a0_8b54_f22398ce3e20
+###  https://w3id.org/emmo/chemicalsubstance#substance_cb320164_c9d7_48a0_8b54_f22398ce3e20
 :substance_cb320164_c9d7_48a0_8b54_f22398ce3e20 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q23767"@en ;
@@ -5908,13 +5908,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumCarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_cb6d2c65_9977_4bb1_987a_5ea828de445f
+###  https://w3id.org/emmo/chemicalsubstance#substance_cb6d2c65_9977_4bb1_987a_5ea828de445f
 :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_015116fe_94ca_4be5_9d14_9d9457a47a72 ;
                                                 skos:prefLabel "ManganeseSaltCompound"@en .
 
 
-###  http://emmo.info/substance#substance_cc155ed5_c60c_4d9f_bfad_fbf6b7c77e57
+###  https://w3id.org/emmo/chemicalsubstance#substance_cc155ed5_c60c_4d9f_bfad_fbf6b7c77e57
 :substance_cc155ed5_c60c_4d9f_bfad_fbf6b7c77e57 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q11158" ;
@@ -5931,7 +5931,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
  ] .
 
 
-###  http://emmo.info/substance#substance_ccdce7d4_b695_4871_84c2_13679807d077
+###  https://w3id.org/emmo/chemicalsubstance#substance_ccdce7d4_b695_4871_84c2_13679807d077
 :substance_ccdce7d4_b695_4871_84c2_13679807d077 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_bed1a22c_8b61_467a_86a0_d24c7b910653 ;
@@ -5945,7 +5945,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumHydroxide"@en .
 
 
-###  http://emmo.info/substance#substance_ccf52cd9_fc33_44c4_903d_e4a2915bd74a
+###  https://w3id.org/emmo/chemicalsubstance#substance_ccf52cd9_fc33_44c4_903d_e4a2915bd74a
 :substance_ccf52cd9_fc33_44c4_903d_e4a2915bd74a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q18234777"@en ;
@@ -5957,7 +5957,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIIChlorate"@en .
 
 
-###  http://emmo.info/substance#substance_cd17ca33_ae3d_4738_8930_547673bf6c1f
+###  https://w3id.org/emmo/chemicalsubstance#substance_cd17ca33_ae3d_4738_8930_547673bf6c1f
 :substance_cd17ca33_ae3d_4738_8930_547673bf6c1f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/substance/472206540" ;
@@ -5965,7 +5965,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumNickelCobaltAluminiumOxide"@en .
 
 
-###  http://emmo.info/substance#substance_cd8581de_2e32_43ee_b0f0_02de1577c69d
+###  https://w3id.org/emmo/chemicalsubstance#substance_cd8581de_2e32_43ee_b0f0_02de1577c69d
 :substance_cd8581de_2e32_43ee_b0f0_02de1577c69d rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -5978,7 +5978,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Osmium"@en .
 
 
-###  http://emmo.info/substance#substance_cdd18f0c_e7b3_4d09_b3dd_c09fe4b1adba
+###  https://w3id.org/emmo/chemicalsubstance#substance_cdd18f0c_e7b3_4d09_b3dd_c09fe4b1adba
 :substance_cdd18f0c_e7b3_4d09_b3dd_c09fe4b1adba rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q31841811"@en ;
@@ -5986,7 +5986,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumCobaltOxide"@en .
 
 
-###  http://emmo.info/substance#substance_cfc02dad_a994_430b_a2b2_fd275016c485
+###  https://w3id.org/emmo/chemicalsubstance#substance_cfc02dad_a994_430b_a2b2_fd275016c485
 :substance_cfc02dad_a994_430b_a2b2_fd275016c485 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411014"@en ;
@@ -5999,7 +5999,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumNitrate"@en .
 
 
-###  http://emmo.info/substance#substance_cfcaa487_a7ee_401b_902a_afc68158a02f
+###  https://w3id.org/emmo/chemicalsubstance#substance_cfcaa487_a7ee_401b_902a_afc68158a02f
 :substance_cfcaa487_a7ee_401b_902a_afc68158a02f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q184832"@en ;
@@ -6012,7 +6012,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "OxalicAcid"@en .
 
 
-###  http://emmo.info/substance#substance_d071c9d0_1358_4d9f_9690_53b7d69e025c
+###  https://w3id.org/emmo/chemicalsubstance#substance_d071c9d0_1358_4d9f_9690_53b7d69e025c
 :substance_d071c9d0_1358_4d9f_9690_53b7d69e025c rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -6025,7 +6025,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Rhodium"@en .
 
 
-###  http://emmo.info/substance#substance_d0d1db46_f674_437f_a322_2913b1eca5de
+###  https://w3id.org/emmo/chemicalsubstance#substance_d0d1db46_f674_437f_a322_2913b1eca5de
 :substance_d0d1db46_f674_437f_a322_2913b1eca5de rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q191700"@en ;
@@ -6037,14 +6037,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BenzoicAcid"@en .
 
 
-###  http://emmo.info/substance#substance_d0e03160_256a_4cb2_a086_8f65d3abf62e
+###  https://w3id.org/emmo/chemicalsubstance#substance_d0e03160_256a_4cb2_a086_8f65d3abf62e
 :substance_d0e03160_256a_4cb2_a086_8f65d3abf62e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 skos:altLabel "Sr(TFSI)2"@en ;
                                                 skos:prefLabel "StrontiumBistrifluoromethanesulfonylimide"@en .
 
 
-###  http://emmo.info/substance#substance_d185fb35_17e0_44df_9a6b_5c93d56b9c99
+###  https://w3id.org/emmo/chemicalsubstance#substance_d185fb35_17e0_44df_9a6b_5c93d56b9c99
 :substance_d185fb35_17e0_44df_9a6b_5c93d56b9c99 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q422434"@en ;
@@ -6057,7 +6057,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumPerchlorate"@en .
 
 
-###  http://emmo.info/substance#substance_d24edc6f_d03b_48ff_8a47_780ad7c2e2b2
+###  https://w3id.org/emmo/chemicalsubstance#substance_d24edc6f_d03b_48ff_8a47_780ad7c2e2b2
 :substance_d24edc6f_d03b_48ff_8a47_780ad7c2e2b2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q309038"@en ;
@@ -6070,7 +6070,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumSulfate"@en .
 
 
-###  http://emmo.info/substance#substance_d27a5bb0_b35d_4133_8b2c_b32e94c899ec
+###  https://w3id.org/emmo/chemicalsubstance#substance_d27a5bb0_b35d_4133_8b2c_b32e94c899ec
 :substance_d27a5bb0_b35d_4133_8b2c_b32e94c899ec rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q107184"@en ;
@@ -6083,7 +6083,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIISulfate"@en .
 
 
-###  http://emmo.info/substance#substance_d2b624f6_6929_41c3_8510_5cf0a57e2877
+###  https://w3id.org/emmo/chemicalsubstance#substance_d2b624f6_6929_41c3_8510_5cf0a57e2877
 :substance_d2b624f6_6929_41c3_8510_5cf0a57e2877 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q82863248"@en ;
@@ -6096,14 +6096,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumSulfite"@en .
 
 
-###  http://emmo.info/substance#substance_d30fb481_a68d_496f_9be3_0e78aef3ef32
+###  https://w3id.org/emmo/chemicalsubstance#substance_d30fb481_a68d_496f_9be3_0e78aef3ef32
 :substance_d30fb481_a68d_496f_9be3_0e78aef3ef32 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 skos:altLabel "Ca(TFSI)2"@en ;
                                                 skos:prefLabel "CalciumBistrifluoromethanesulfonylimide"@en .
 
 
-###  http://emmo.info/substance#substance_d36fbe2f_6b0a_4178_b6ca_7373bdefcb51
+###  https://w3id.org/emmo/chemicalsubstance#substance_d36fbe2f_6b0a_4178_b6ca_7373bdefcb51
 :substance_d36fbe2f_6b0a_4178_b6ca_7373bdefcb51 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7e716191_b301_4d63_bb6b_93323ffe51bf ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411030"@en ;
@@ -6116,7 +6116,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CarboxymethylCellulose"@en .
 
 
-###  http://emmo.info/substance#substance_d3739474_ed71_4e61_b9ae_d7dc2c091179
+###  https://w3id.org/emmo/chemicalsubstance#substance_d3739474_ed71_4e61_b9ae_d7dc2c091179
 :substance_d3739474_ed71_4e61_b9ae_d7dc2c091179 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4119952"@en ;
@@ -6129,7 +6129,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIITriflate"@en .
 
 
-###  http://emmo.info/substance#substance_d441cd55_e84c_450f_a91e_9585b3c24527
+###  https://w3id.org/emmo/chemicalsubstance#substance_d441cd55_e84c_450f_a91e_9585b3c24527
 :substance_d441cd55_e84c_450f_a91e_9585b3c24527 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_8e5448fc_1916_4afb_9fd9_2489797f6922 ;
@@ -6143,7 +6143,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumHydroxide"@en .
 
 
-###  http://emmo.info/substance#substance_d459562f_94cb_4b2d_902f_788399c64cfc
+###  https://w3id.org/emmo/chemicalsubstance#substance_d459562f_94cb_4b2d_902f_788399c64cfc
 :substance_d459562f_94cb_4b2d_902f_788399c64cfc rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409224"@en ;
@@ -6156,7 +6156,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumCarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_d47303ca_3445_4579_9684_21aa153140df
+###  https://w3id.org/emmo/chemicalsubstance#substance_d47303ca_3445_4579_9684_21aa153140df
 :substance_d47303ca_3445_4579_9684_21aa153140df rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/74125" ;
@@ -6167,7 +6167,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PentafluorophenylIsocyanate"@en .
 
 
-###  http://emmo.info/substance#substance_d4e965c3_80a8_4d13_a7b9_f1402dd3ae67
+###  https://w3id.org/emmo/chemicalsubstance#substance_d4e965c3_80a8_4d13_a7b9_f1402dd3ae67
 :substance_d4e965c3_80a8_4d13_a7b9_f1402dd3ae67 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_78400dc0_97b0_4d59_8ea6_30bb703f428c ;
@@ -6180,7 +6180,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Selenium"@en .
 
 
-###  http://emmo.info/substance#substance_d53259a7_0d9c_48b9_a6c1_4418169df303
+###  https://w3id.org/emmo/chemicalsubstance#substance_d53259a7_0d9c_48b9_a6c1_4418169df303
 :substance_d53259a7_0d9c_48b9_a6c1_4418169df303 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_6c0cc397_d8c4_4473_a09f_1e5de568e0dd ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q5309"@en ;
@@ -6193,7 +6193,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Graphite"@en .
 
 
-###  http://emmo.info/substance#substance_d53de966_29a4_4a1b_b166_a8c7734eeae0
+###  https://w3id.org/emmo/chemicalsubstance#substance_d53de966_29a4_4a1b_b166_a8c7734eeae0
 :substance_d53de966_29a4_4a1b_b166_a8c7734eeae0 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407446"@en ;
@@ -6206,7 +6206,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumChlorate"@en .
 
 
-###  http://emmo.info/substance#substance_d5bf1391_1bc2_472d_adc8_1b2407d2af70
+###  https://w3id.org/emmo/chemicalsubstance#substance_d5bf1391_1bc2_472d_adc8_1b2407d2af70
 :substance_d5bf1391_1bc2_472d_adc8_1b2407d2af70 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421538"@en ;
@@ -6219,7 +6219,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumNitrite"@en .
 
 
-###  http://emmo.info/substance#substance_d5c2e705_2e15_4c97_9d6a_0c90afa606ec
+###  https://w3id.org/emmo/chemicalsubstance#substance_d5c2e705_2e15_4c97_9d6a_0c90afa606ec
 :substance_d5c2e705_2e15_4c97_9d6a_0c90afa606ec rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q416688"@en ;
@@ -6232,7 +6232,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIISulfide"@en .
 
 
-###  http://emmo.info/substance#substance_d6031563_07c3_4cf7_852e_474dce2acc1c
+###  https://w3id.org/emmo/chemicalsubstance#substance_d6031563_07c3_4cf7_852e_474dce2acc1c
 :substance_d6031563_07c3_4cf7_852e_474dce2acc1c rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a4a5b239_d88e_4e03_a763_0bf2a3dd0f47 ;
@@ -6246,7 +6246,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Strontium"@en .
 
 
-###  http://emmo.info/substance#substance_d673ceb2_3045_4e2e_8cad_56f5169b542f
+###  https://w3id.org/emmo/chemicalsubstance#substance_d673ceb2_3045_4e2e_8cad_56f5169b542f
 :substance_d673ceb2_3045_4e2e_8cad_56f5169b542f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_001ca83b_5372_4d77_a836_4d48074b7e63 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Titanium_dioxide"@en ;
@@ -6259,7 +6259,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TitaniumDioxide"@en .
 
 
-###  http://emmo.info/substance#substance_d6b4453f_6a41_446a_874c_5fcce4948ef2
+###  https://w3id.org/emmo/chemicalsubstance#substance_d6b4453f_6a41_446a_874c_5fcce4948ef2
 :substance_d6b4453f_6a41_446a_874c_5fcce4948ef2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q208451"@en ;
@@ -6272,7 +6272,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumChloride"@en .
 
 
-###  http://emmo.info/substance#substance_d6ed8fcd_4d21_4401_b16c_478985799100
+###  https://w3id.org/emmo/chemicalsubstance#substance_d6ed8fcd_4d21_4401_b16c_478985799100
 :substance_d6ed8fcd_4d21_4401_b16c_478985799100 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q420370"@en ;
@@ -6285,7 +6285,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIIBromide"@en .
 
 
-###  http://emmo.info/substance#substance_d729ecb6_dd34_43fa_a67d_33045483fa7c
+###  https://w3id.org/emmo/chemicalsubstance#substance_d729ecb6_dd34_43fa_a67d_33045483fa7c
 :substance_d729ecb6_dd34_43fa_a67d_33045483fa7c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q7553385"@en ;
@@ -6298,7 +6298,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumTriflate"@en .
 
 
-###  http://emmo.info/substance#substance_d72cdf03_965d_4149_865f_d44ed9e5e1b8
+###  https://w3id.org/emmo/chemicalsubstance#substance_d72cdf03_965d_4149_865f_d44ed9e5e1b8
 :substance_d72cdf03_965d_4149_865f_d44ed9e5e1b8 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q15411014"@en ;
@@ -6310,7 +6310,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "GlycidicAcid"@en .
 
 
-###  http://emmo.info/substance#substance_d7314c57_c073_4a7a_afa3_e81fea4b44a3
+###  https://w3id.org/emmo/chemicalsubstance#substance_d7314c57_c073_4a7a_afa3_e81fea4b44a3
 :substance_d7314c57_c073_4a7a_afa3_e81fea4b44a3 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_cac14194_2d5f_4fe6_b794_a9319f6d76ee ;
@@ -6323,7 +6323,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Neon"@en .
 
 
-###  http://emmo.info/substance#substance_d7f2ab2a_e3ff_4aea_8cf1_862df545c882
+###  https://w3id.org/emmo/chemicalsubstance#substance_d7f2ab2a_e3ff_4aea_8cf1_862df545c882
 :substance_d7f2ab2a_e3ff_4aea_8cf1_862df545c882 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421972"@en ;
@@ -6335,7 +6335,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MalonicAcid"@en .
 
 
-###  http://emmo.info/substance#substance_d9a71272_91cb_45d7_8e4b_960ec3c79981
+###  https://w3id.org/emmo/chemicalsubstance#substance_d9a71272_91cb_45d7_8e4b_960ec3c79981
 :substance_d9a71272_91cb_45d7_8e4b_960ec3c79981 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204679"@en ;
@@ -6348,7 +6348,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincBromide"@en .
 
 
-###  http://emmo.info/substance#substance_d9c342d8_497e_4378_96e2_3b9b2c42cf17
+###  https://w3id.org/emmo/chemicalsubstance#substance_d9c342d8_497e_4378_96e2_3b9b2c42cf17
 :substance_d9c342d8_497e_4378_96e2_3b9b2c42cf17 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204873"@en ;
@@ -6361,13 +6361,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumCarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_d9f73522_049b_4542_909d_d7daefa9613b
+###  https://w3id.org/emmo/chemicalsubstance#substance_d9f73522_049b_4542_909d_d7daefa9613b
 :substance_d9f73522_049b_4542_909d_d7daefa9613b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "MercuryOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_da1623c4_3d3b_4c9d_8601_ea055848df39
+###  https://w3id.org/emmo/chemicalsubstance#substance_da1623c4_3d3b_4c9d_8601_ea055848df39
 :substance_da1623c4_3d3b_4c9d_8601_ea055848df39 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407270"@en ;
@@ -6380,7 +6380,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumChloride"@en .
 
 
-###  http://emmo.info/substance#substance_da29bb03_cd0d_44b2_9c94_f62ae56f5def
+###  https://w3id.org/emmo/chemicalsubstance#substance_da29bb03_cd0d_44b2_9c94_f62ae56f5def
 :substance_da29bb03_cd0d_44b2_9c94_f62ae56f5def rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1223259"@en ;
@@ -6392,7 +6392,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Ethylmonoglyme"@en .
 
 
-###  http://emmo.info/substance#substance_da48c6df_3730_490e_a970_44ef4a6cbf4e
+###  https://w3id.org/emmo/chemicalsubstance#substance_da48c6df_3730_490e_a970_44ef4a6cbf4e
 :substance_da48c6df_3730_490e_a970_44ef4a6cbf4e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q27272874"@en ;
@@ -6404,13 +6404,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIICarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_dae2320d_be18_44ba_90bd_8176decc4b47
+###  https://w3id.org/emmo/chemicalsubstance#substance_dae2320d_be18_44ba_90bd_8176decc4b47
 :substance_dae2320d_be18_44ba_90bd_8176decc4b47 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f07ae87e_b56e_4835_8a28_04c6c7dfbaa2 ;
                                                 skos:prefLabel "Cation"@en .
 
 
-###  http://emmo.info/substance#substance_db74b6b7_09fc_40db_a7d5_6eb86b69192a
+###  https://w3id.org/emmo/chemicalsubstance#substance_db74b6b7_09fc_40db_a7d5_6eb86b69192a
 :substance_db74b6b7_09fc_40db_a7d5_6eb86b69192a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_155e894b_66de_4cda_9dbe_adbeca7d8102 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q129163"@en ;
@@ -6423,7 +6423,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TinIVOxide"@en .
 
 
-###  http://emmo.info/substance#substance_db926a48_0b3c_4f6d_89f5_a333af85ecbd
+###  https://w3id.org/emmo/chemicalsubstance#substance_db926a48_0b3c_4f6d_89f5_a333af85ecbd
 :substance_db926a48_0b3c_4f6d_89f5_a333af85ecbd rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q3877375"@en ;
@@ -6435,7 +6435,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincNitrite"@en .
 
 
-###  http://emmo.info/substance#substance_dbbedf09_18c4_416a_99c2_f381a74d2551
+###  https://w3id.org/emmo/chemicalsubstance#substance_dbbedf09_18c4_416a_99c2_f381a74d2551
 :substance_dbbedf09_18c4_416a_99c2_f381a74d2551 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/3082513" ;
@@ -6446,7 +6446,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TetrapotassiumHeptaiodobismuthate"@en .
 
 
-###  http://emmo.info/substance#substance_dc592618_13ec_498a_834b_2188ecb9535d
+###  https://w3id.org/emmo/chemicalsubstance#substance_dc592618_13ec_498a_834b_2188ecb9535d
 :substance_dc592618_13ec_498a_834b_2188ecb9535d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q408464"@en ;
@@ -6459,7 +6459,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumSulfide"@en .
 
 
-###  http://emmo.info/substance#substance_dc5fb846_1824_40f8_9834_81f118aa1c2d
+###  https://w3id.org/emmo/chemicalsubstance#substance_dc5fb846_1824_40f8_9834_81f118aa1c2d
 :substance_dc5fb846_1824_40f8_9834_81f118aa1c2d rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -6472,13 +6472,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Mercury"@en .
 
 
-###  http://emmo.info/substance#substance_dc68514f_b592_4e1b_a00f_fbb29f2fafbd
+###  https://w3id.org/emmo/chemicalsubstance#substance_dc68514f_b592_4e1b_a00f_fbb29f2fafbd
 :substance_dc68514f_b592_4e1b_a00f_fbb29f2fafbd rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7e716191_b301_4d63_bb6b_93323ffe51bf ;
                                                 skos:prefLabel "IonomerCompound"@en .
 
 
-###  http://emmo.info/substance#substance_dc9ae81a_b5ac_45b6_8b66_9ee6b821d475
+###  https://w3id.org/emmo/chemicalsubstance#substance_dc9ae81a_b5ac_45b6_8b66_9ee6b821d475
 :substance_dc9ae81a_b5ac_45b6_8b66_9ee6b821d475 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7e716191_b301_4d63_bb6b_93323ffe51bf ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q410083"@en ;
@@ -6488,7 +6488,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PolyethyleneGlycol"@en .
 
 
-###  http://emmo.info/substance#substance_dcb0d128_c3db_4c91_84ba_af9df1688766
+###  https://w3id.org/emmo/chemicalsubstance#substance_dcb0d128_c3db_4c91_84ba_af9df1688766
 :substance_dcb0d128_c3db_4c91_84ba_af9df1688766 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc9ba950_96c1_4ac2_a0e2_1c4f7f001b1d ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q419205"@en ;
@@ -6501,7 +6501,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadII_IVOxide"@en .
 
 
-###  http://emmo.info/substance#substance_dcdbdbed_2e20_40d1_a7a5_5761de7f0618
+###  https://w3id.org/emmo/chemicalsubstance#substance_dcdbdbed_2e20_40d1_a7a5_5761de7f0618
 :substance_dcdbdbed_2e20_40d1_a7a5_5761de7f0618 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a4d05f1_dd15_465b_8b44_704238e20813 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407674"@en ;
@@ -6514,13 +6514,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseDioxide"@en .
 
 
-###  http://emmo.info/substance#substance_dce90b66_3414_4f5d_b818_4a0e4339e949
+###  https://w3id.org/emmo/chemicalsubstance#substance_dce90b66_3414_4f5d_b818_4a0e4339e949
 :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_015116fe_94ca_4be5_9d14_9d9457a47a72 ;
                                                 skos:prefLabel "NickelSaltCompound"@en .
 
 
-###  http://emmo.info/substance#substance_dd746094_1893_4b77_9c07_13b3bd94a742
+###  https://w3id.org/emmo/chemicalsubstance#substance_dd746094_1893_4b77_9c07_13b3bd94a742
 :substance_dd746094_1893_4b77_9c07_13b3bd94a742 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2786508"@en ;
@@ -6534,21 +6534,21 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Hexafluorophosphate"@en .
 
 
-###  http://emmo.info/substance#substance_dd8823eb_ea6f_49f2_a4f9_d21828cb8b8e
+###  https://w3id.org/emmo/chemicalsubstance#substance_dd8823eb_ea6f_49f2_a4f9_d21828cb8b8e
 :substance_dd8823eb_ea6f_49f2_a4f9_d21828cb8b8e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 skos:altLabel "Ca(TFOB)2"@en ;
                                                 skos:prefLabel "CalciumTrifluoromethanesulfonyloxalatoborate"@en .
 
 
-###  http://emmo.info/substance#substance_de038959_9251_48d1_a141_3684f14d957f
+###  https://w3id.org/emmo/chemicalsubstance#substance_de038959_9251_48d1_a141_3684f14d957f
 :substance_de038959_9251_48d1_a141_3684f14d957f rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ;
                                                 emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "substance that can act as an acid or a base"@en ;
                                                 skos:prefLabel "AmphotericCompound"@en .
 
 
-###  http://emmo.info/substance#substance_de52b69b_3c86_4f1c_a467_7a1fa411bc36
+###  https://w3id.org/emmo/chemicalsubstance#substance_de52b69b_3c86_4f1c_a467_7a1fa411bc36
 :substance_de52b69b_3c86_4f1c_a467_7a1fa411bc36 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q417806"@en ;
@@ -6561,7 +6561,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIISulfide"@en .
 
 
-###  http://emmo.info/substance#substance_dedc4519_9651_415e_95e8_1ed03b195244
+###  https://w3id.org/emmo/chemicalsubstance#substance_dedc4519_9651_415e_95e8_1ed03b195244
 :substance_dedc4519_9651_415e_95e8_1ed03b195244 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q412015"@en ;
@@ -6574,7 +6574,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumPerchlorate"@en .
 
 
-###  http://emmo.info/substance#substance_df038b95_6c39_4fce_8c16_237057a08c0b
+###  https://w3id.org/emmo/chemicalsubstance#substance_df038b95_6c39_4fce_8c16_237057a08c0b
 :substance_df038b95_6c39_4fce_8c16_237057a08c0b rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -6587,7 +6587,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Chromium"@en .
 
 
-###  http://emmo.info/substance#substance_df24fad8_7ef0_4330_a3f2_c4d65d9a3be8
+###  https://w3id.org/emmo/chemicalsubstance#substance_df24fad8_7ef0_4330_a3f2_c4d65d9a3be8
 :substance_df24fad8_7ef0_4330_a3f2_c4d65d9a3be8 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72488070"@en ;
@@ -6599,7 +6599,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumTriflate"@en .
 
 
-###  http://emmo.info/substance#substance_df5d45a8_ce23_46f7_92b2_84dd28942b0d
+###  https://w3id.org/emmo/chemicalsubstance#substance_df5d45a8_ce23_46f7_92b2_84dd28942b0d
 :substance_df5d45a8_ce23_46f7_92b2_84dd28942b0d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q18212211"@en ;
@@ -6612,7 +6612,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIIPhosphate"@en .
 
 
-###  http://emmo.info/substance#substance_df72af75_cc1c_4286_aeb8_66de90ef276d
+###  https://w3id.org/emmo/chemicalsubstance#substance_df72af75_cc1c_4286_aeb8_66de90ef276d
 :substance_df72af75_cc1c_4286_aeb8_66de90ef276d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/5257893" ;
@@ -6623,7 +6623,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Bis(fluorosulfonyl)amide"@en .
 
 
-###  http://emmo.info/substance#substance_dfa3d84e_279c_47d0_ad87_5a30b1a325ce
+###  https://w3id.org/emmo/chemicalsubstance#substance_dfa3d84e_279c_47d0_ad87_5a30b1a325ce
 :substance_dfa3d84e_279c_47d0_ad87_5a30b1a325ce rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/170058" ;
@@ -6635,7 +6635,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIITetrafluoroborate"@en .
 
 
-###  http://emmo.info/substance#substance_e04eb6c9_7de2_46d4_bab2_25ff819d74ab
+###  https://w3id.org/emmo/chemicalsubstance#substance_e04eb6c9_7de2_46d4_bab2_25ff819d74ab
 :substance_e04eb6c9_7de2_46d4_bab2_25ff819d74ab rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7e716191_b301_4d63_bb6b_93323ffe51bf ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q143252"@en ;
@@ -6645,7 +6645,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Polyterafluoroethylene"@en .
 
 
-###  http://emmo.info/substance#substance_e0b08aed_a2c6_4168_84fc_940e4d0bdd97
+###  https://w3id.org/emmo/chemicalsubstance#substance_e0b08aed_a2c6_4168_84fc_940e4d0bdd97
 :substance_e0b08aed_a2c6_4168_84fc_940e4d0bdd97 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q16685924"@en ;
@@ -6658,7 +6658,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIIPerchlorate"@en .
 
 
-###  http://emmo.info/substance#substance_e128782f_8c69_43b2_9c3c_9efb31e8a6b5
+###  https://w3id.org/emmo/chemicalsubstance#substance_e128782f_8c69_43b2_9c3c_9efb31e8a6b5
 :substance_e128782f_8c69_43b2_9c3c_9efb31e8a6b5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4337166"@en ;
@@ -6670,7 +6670,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumPhosphate"@en .
 
 
-###  http://emmo.info/substance#substance_e1569fd3_34ac_440c_845c_f7c85f59c88d
+###  https://w3id.org/emmo/chemicalsubstance#substance_e1569fd3_34ac_440c_845c_f7c85f59c88d
 :substance_e1569fd3_34ac_440c_845c_f7c85f59c88d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4321627"@en ;
@@ -6682,7 +6682,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumNitrite"@en .
 
 
-###  http://emmo.info/substance#substance_e1bfc0f5_7192_49f2_9ce1_1be2467e0b7a
+###  https://w3id.org/emmo/chemicalsubstance#substance_e1bfc0f5_7192_49f2_9ce1_1be2467e0b7a
 :substance_e1bfc0f5_7192_49f2_9ce1_1be2467e0b7a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204863"@en ;
@@ -6695,7 +6695,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincNitrate"@en .
 
 
-###  http://emmo.info/substance#substance_e1d2936e_8382_463e_bd83_f7bac40c355b
+###  https://w3id.org/emmo/chemicalsubstance#substance_e1d2936e_8382_463e_bd83_f7bac40c355b
 :substance_e1d2936e_8382_463e_bd83_f7bac40c355b rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a9a6507f_9c61_44d3_bd86_f1ebf763e150 ;
@@ -6709,7 +6709,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Antimony"@en .
 
 
-###  http://emmo.info/substance#substance_e1de5285_dbc5_4845_9f8d_9821708681ca
+###  https://w3id.org/emmo/chemicalsubstance#substance_e1de5285_dbc5_4845_9f8d_9821708681ca
 :substance_e1de5285_dbc5_4845_9f8d_9821708681ca rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407666"@en ;
@@ -6722,7 +6722,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumNitrate"@en .
 
 
-###  http://emmo.info/substance#substance_e1e6ff98_0725_4d27_ab21_2ca5a95371f0
+###  https://w3id.org/emmo/chemicalsubstance#substance_e1e6ff98_0725_4d27_ab21_2ca5a95371f0
 :substance_e1e6ff98_0725_4d27_ab21_2ca5a95371f0 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -6735,7 +6735,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Silver"@en .
 
 
-###  http://emmo.info/substance#substance_e24e19b5_57b2_44ab_8ef8_c5ce6c08a16c
+###  https://w3id.org/emmo/chemicalsubstance#substance_e24e19b5_57b2_44ab_8ef8_c5ce6c08a16c
 :substance_e24e19b5_57b2_44ab_8ef8_c5ce6c08a16c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q79566"@en ;
@@ -6748,7 +6748,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumIodide"@en .
 
 
-###  http://emmo.info/substance#substance_e2764cfb_4fa6_4fe9_85e0_1dfe69a37ff1
+###  https://w3id.org/emmo/chemicalsubstance#substance_e2764cfb_4fa6_4fe9_85e0_1dfe69a37ff1
 :substance_e2764cfb_4fa6_4fe9_85e0_1dfe69a37ff1 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q413953"@en ;
@@ -6761,7 +6761,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumIodide"@en .
 
 
-###  http://emmo.info/substance#substance_e2c251a7_27b0_4345_a986_eb6bb8234c74
+###  https://w3id.org/emmo/chemicalsubstance#substance_e2c251a7_27b0_4345_a986_eb6bb8234c74
 :substance_e2c251a7_27b0_4345_a986_eb6bb8234c74 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a639df56_1fb2_47f3_8069_c929b5a84b86 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421440"@en ;
@@ -6774,7 +6774,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "VanadiumIVOxide"@en .
 
 
-###  http://emmo.info/substance#substance_e3a3dc4f_b910_49e3_b66d_c25ce4889d68
+###  https://w3id.org/emmo/chemicalsubstance#substance_e3a3dc4f_b910_49e3_b66d_c25ce4889d68
 :substance_e3a3dc4f_b910_49e3_b66d_c25ce4889d68 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407849"@en ;
@@ -6787,7 +6787,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIIChloride"@en .
 
 
-###  http://emmo.info/substance#substance_e4512250_04d1_4ad3_9c55_71e7f7db1b98
+###  https://w3id.org/emmo/chemicalsubstance#substance_e4512250_04d1_4ad3_9c55_71e7f7db1b98
 :substance_e4512250_04d1_4ad3_9c55_71e7f7db1b98 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q15779"@en ;
@@ -6801,7 +6801,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Toluene"@en .
 
 
-###  http://emmo.info/substance#substance_e54b6547_e915_4c10_9864_30e6a7b456d7
+###  https://w3id.org/emmo/chemicalsubstance#substance_e54b6547_e915_4c10_9864_30e6a7b456d7
 :substance_e54b6547_e915_4c10_9864_30e6a7b456d7 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_88748886_9b7c_4df0_91eb_fe91ecc1b9cd ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2366389"@en ;
@@ -6813,7 +6813,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ChromiumIVOxide"@en .
 
 
-###  http://emmo.info/substance#substance_e76e313b_6052_4ccf_ad80_8f88815c38da
+###  https://w3id.org/emmo/chemicalsubstance#substance_e76e313b_6052_4ccf_ad80_8f88815c38da
 :substance_e76e313b_6052_4ccf_ad80_8f88815c38da rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bed1a22c_8b61_467a_86a0_d24c7b910653 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q132428"@en ;
@@ -6826,7 +6826,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumHydroxide"@en .
 
 
-###  http://emmo.info/substance#substance_e7a4f9ca_e221_4080_8281_304c3a8290f9
+###  https://w3id.org/emmo/chemicalsubstance#substance_e7a4f9ca_e221_4080_8281_304c3a8290f9
 :substance_e7a4f9ca_e221_4080_8281_304c3a8290f9 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421857"@en ;
@@ -6839,7 +6839,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumSulfate"@en .
 
 
-###  http://emmo.info/substance#substance_e7be17c8_49e3_43d9_8859_82e39c5ca594
+###  https://w3id.org/emmo/chemicalsubstance#substance_e7be17c8_49e3_43d9_8859_82e39c5ca594
 :substance_e7be17c8_49e3_43d9_8859_82e39c5ca594 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q425190"@en ;
@@ -6852,7 +6852,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumTetrafluoroborate"@en .
 
 
-###  http://emmo.info/substance#substance_e884ea99_9b69_4b8e_b932_9c47e1c8ce0c
+###  https://w3id.org/emmo/chemicalsubstance#substance_e884ea99_9b69_4b8e_b932_9c47e1c8ce0c
 :substance_e884ea99_9b69_4b8e_b932_9c47e1c8ce0c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/substance/385878341" ;
@@ -6860,7 +6860,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumBisoxalatoborate"@en .
 
 
-###  http://emmo.info/substance#substance_e8fafdc8_6cd3_4dd0_9630_10ca8e3f1827
+###  https://w3id.org/emmo/chemicalsubstance#substance_e8fafdc8_6cd3_4dd0_9630_10ca8e3f1827
 :substance_e8fafdc8_6cd3_4dd0_9630_10ca8e3f1827 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q29565403"@en ;
@@ -6872,7 +6872,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumManganeseOxide"@en .
 
 
-###  http://emmo.info/substance#substance_e9010b6e_e43b_4454_8231_e67ab1a81a18
+###  https://w3id.org/emmo/chemicalsubstance#substance_e9010b6e_e43b_4454_8231_e67ab1a81a18
 :substance_e9010b6e_e43b_4454_8231_e67ab1a81a18 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421443"@en ;
@@ -6885,7 +6885,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIIIodide"@en .
 
 
-###  http://emmo.info/substance#substance_ea0471d2_cfe0_4b64_9b0d_118254ed3dcc
+###  https://w3id.org/emmo/chemicalsubstance#substance_ea0471d2_cfe0_4b64_9b0d_118254ed3dcc
 :substance_ea0471d2_cfe0_4b64_9b0d_118254ed3dcc rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_52da9471_9979_44b0_a415_63c72110fd43 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411235"@en ;
@@ -6898,7 +6898,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IronII_IIIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_ea68e1a4_6be8_4686_8701_ba88b40d00b7
+###  https://w3id.org/emmo/chemicalsubstance#substance_ea68e1a4_6be8_4686_8701_ba88b40d00b7
 :substance_ea68e1a4_6be8_4686_8701_ba88b40d00b7 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -6912,7 +6912,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "DimethylSulfoxide"@en .
 
 
-###  http://emmo.info/substance#substance_ead9b571_f6ec_46da_955c_7049ecee9366
+###  https://w3id.org/emmo/chemicalsubstance#substance_ead9b571_f6ec_46da_955c_7049ecee9366
 :substance_ead9b571_f6ec_46da_955c_7049ecee9366 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q416502"@en ;
@@ -6924,7 +6924,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumChlorate"@en .
 
 
-###  http://emmo.info/substance#substance_eada6f39_231c_45be_ae3e_fd9a67fe0003
+###  https://w3id.org/emmo/chemicalsubstance#substance_eada6f39_231c_45be_ae3e_fd9a67fe0003
 :substance_eada6f39_231c_45be_ae3e_fd9a67fe0003 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421490"@en ;
@@ -6937,7 +6937,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIINitrate"@en .
 
 
-###  http://emmo.info/substance#substance_ec7bf3bb_30b3_4f2c_a12d_9f9f9006a955
+###  https://w3id.org/emmo/chemicalsubstance#substance_ec7bf3bb_30b3_4f2c_a12d_9f9f9006a955
 :substance_ec7bf3bb_30b3_4f2c_a12d_9f9f9006a955 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q8072312"@en ;
@@ -6950,7 +6950,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincTriflate"@en .
 
 
-###  http://emmo.info/substance#substance_ecc8bfbf_0a0c_42f4_8296_8ab1278c5e69
+###  https://w3id.org/emmo/chemicalsubstance#substance_ecc8bfbf_0a0c_42f4_8296_8ab1278c5e69
 :substance_ecc8bfbf_0a0c_42f4_8296_8ab1278c5e69 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q422426"@en ;
@@ -6963,7 +6963,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumFluoride"@en .
 
 
-###  http://emmo.info/substance#substance_eccb603e_76be_435e_902f_7ebd9f26690b
+###  https://w3id.org/emmo/chemicalsubstance#substance_eccb603e_76be_435e_902f_7ebd9f26690b
 :substance_eccb603e_76be_435e_902f_7ebd9f26690b rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q21099559"@en ;
@@ -6975,7 +6975,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TrimethoxyMethylSilane"@en .
 
 
-###  http://emmo.info/substance#substance_ecd84623_43e2_457e_8988_1bfc9d1fb818
+###  https://w3id.org/emmo/chemicalsubstance#substance_ecd84623_43e2_457e_8988_1bfc9d1fb818
 :substance_ecd84623_43e2_457e_8988_1bfc9d1fb818 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f5b930f9_2f95_4268_993c_ff6b57ae7691 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q193956"@en ;
@@ -6988,7 +6988,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PerchloricAcid"@en .
 
 
-###  http://emmo.info/substance#substance_ececb906_d081_470b_aa5c_5ea526b0baf8
+###  https://w3id.org/emmo/chemicalsubstance#substance_ececb906_d081_470b_aa5c_5ea526b0baf8
 :substance_ececb906_d081_470b_aa5c_5ea526b0baf8 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q5138693"@en ;
@@ -7001,7 +7001,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIIChlorate"@en .
 
 
-###  http://emmo.info/substance#substance_ed314de3_c1d7_4901_9fd7_539c6e3de550
+###  https://w3id.org/emmo/chemicalsubstance#substance_ed314de3_c1d7_4901_9fd7_539c6e3de550
 :substance_ed314de3_c1d7_4901_9fd7_539c6e3de550 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -7014,7 +7014,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Tantalum"@en .
 
 
-###  http://emmo.info/substance#substance_ed8ce122_1ad7_4760_b32b_96610351ef26
+###  https://w3id.org/emmo/chemicalsubstance#substance_ed8ce122_1ad7_4760_b32b_96610351ef26
 :substance_ed8ce122_1ad7_4760_b32b_96610351ef26 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_2e4767fb_2c1b_43e5_9716_acd3f34b4301 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1676613"@en ;
@@ -7026,7 +7026,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PlatinumOxide"@en .
 
 
-###  http://emmo.info/substance#substance_edae7b22_461b_432b_b737_3c93feb69b0e
+###  https://w3id.org/emmo/chemicalsubstance#substance_edae7b22_461b_432b_b737_3c93feb69b0e
 :substance_edae7b22_461b_432b_b737_3c93feb69b0e rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q12370" ;
@@ -7043,7 +7043,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
  ] .
 
 
-###  http://emmo.info/substance#substance_edef7f16_a517_4577_91b1_a90099869f1b
+###  https://w3id.org/emmo/chemicalsubstance#substance_edef7f16_a517_4577_91b1_a90099869f1b
 :substance_edef7f16_a517_4577_91b1_a90099869f1b rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72516362"@en ;
@@ -7055,7 +7055,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "VinylEthyleneCarbonate"@en .
 
 
-###  http://emmo.info/substance#substance_ee2e195f_7b51_4444_a472_f76ea9bb5943
+###  https://w3id.org/emmo/chemicalsubstance#substance_ee2e195f_7b51_4444_a472_f76ea9bb5943
 :substance_ee2e195f_7b51_4444_a472_f76ea9bb5943 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2988108"@en ;
@@ -7068,7 +7068,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "OXylene"@en .
 
 
-###  http://emmo.info/substance#substance_f028e380_2abf_49b8_8e65_9ae788791f3c
+###  https://w3id.org/emmo/chemicalsubstance#substance_f028e380_2abf_49b8_8e65_9ae788791f3c
 :substance_f028e380_2abf_49b8_8e65_9ae788791f3c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4498184"@en ;
@@ -7081,13 +7081,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIIChlorate"@en .
 
 
-###  http://emmo.info/substance#substance_f07ae87e_b56e_4835_8a28_04c6c7dfbaa2
+###  https://w3id.org/emmo/chemicalsubstance#substance_f07ae87e_b56e_4835_8a28_04c6c7dfbaa2
 :substance_f07ae87e_b56e_4835_8a28_04c6c7dfbaa2 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_21205421_5783_4d3e_81e5_10c5d894a88a ;
                                                 skos:prefLabel "Ion"@en .
 
 
-###  http://emmo.info/substance#substance_f12d9fa2_a9a8_44e9_8f24_ceb9e74b0731
+###  https://w3id.org/emmo/chemicalsubstance#substance_f12d9fa2_a9a8_44e9_8f24_ceb9e74b0731
 :substance_f12d9fa2_a9a8_44e9_8f24_ceb9e74b0731 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72487579"@en ;
@@ -7099,7 +7099,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumBisfluorosulfonylimide"@en .
 
 
-###  http://emmo.info/substance#substance_f1e2238d_f5eb_45b0_9209_f493f821fffc
+###  https://w3id.org/emmo/chemicalsubstance#substance_f1e2238d_f5eb_45b0_9209_f493f821fffc
 :substance_f1e2238d_f5eb_45b0_9209_f493f821fffc rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409184"@en ;
@@ -7112,7 +7112,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Ethylbenzene"@en .
 
 
-###  http://emmo.info/substance#substance_f1e874cf_3e5e_46e3_9bb9_0befc3f7361a
+###  https://w3id.org/emmo/chemicalsubstance#substance_f1e874cf_3e5e_46e3_9bb9_0befc3f7361a
 :substance_f1e874cf_3e5e_46e3_9bb9_0befc3f7361a rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -7126,7 +7126,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Pyridine"@en .
 
 
-###  http://emmo.info/substance#substance_f1f123bb_59a4_429f_994b_c39415e4c444
+###  https://w3id.org/emmo/chemicalsubstance#substance_f1f123bb_59a4_429f_994b_c39415e4c444
 :substance_f1f123bb_59a4_429f_994b_c39415e4c444 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409199"@en ;
@@ -7139,13 +7139,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumAcetate"@en .
 
 
-###  http://emmo.info/substance#substance_f24cfd50_5d01_4e02_88b5_44a609cfa432
+###  https://w3id.org/emmo/chemicalsubstance#substance_f24cfd50_5d01_4e02_88b5_44a609cfa432
 :substance_f24cfd50_5d01_4e02_88b5_44a609cfa432 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "SilverOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_f2dad0d0_8392_490d_932c_d920f8ff3d64
+###  https://w3id.org/emmo/chemicalsubstance#substance_f2dad0d0_8392_490d_932c_d920f8ff3d64
 :substance_f2dad0d0_8392_490d_932c_d920f8ff3d64 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2749498"@en ;
@@ -7158,7 +7158,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumNitrite"@en .
 
 
-###  http://emmo.info/substance#substance_f2e48e9e_f774_4f42_939f_1fe522efb7c8
+###  https://w3id.org/emmo/chemicalsubstance#substance_f2e48e9e_f774_4f42_939f_1fe522efb7c8
 :substance_f2e48e9e_f774_4f42_939f_1fe522efb7c8 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7e716191_b301_4d63_bb6b_93323ffe51bf ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q146393"@en ;
@@ -7171,13 +7171,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PolyvinylideneFluoride"@en .
 
 
-###  http://emmo.info/substance#substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6
+###  https://w3id.org/emmo/chemicalsubstance#substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6
 :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_8c40be1f_0931_4db9_832f_cb63556f6a5a ;
                                                 skos:prefLabel "AluminiumSaltCompound"@en .
 
 
-###  http://emmo.info/substance#substance_f3e7979a_e3ef_450a_8762_7d8778afe478
+###  https://w3id.org/emmo/chemicalsubstance#substance_f3e7979a_e3ef_450a_8762_7d8778afe478
 :substance_f3e7979a_e3ef_450a_8762_7d8778afe478 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q120861607"@en ;
@@ -7189,7 +7189,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumNickelManganeseOxide"@en .
 
 
-###  http://emmo.info/substance#substance_f44338b9_7672_4e53_b002_3d980911c349
+###  https://w3id.org/emmo/chemicalsubstance#substance_f44338b9_7672_4e53_b002_3d980911c349
 :substance_f44338b9_7672_4e53_b002_3d980911c349 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q3234708"@en ;
@@ -7202,7 +7202,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MXylene"@en .
 
 
-###  http://emmo.info/substance#substance_f4dffee2_c642_4114_a748_5e93b3908380
+###  https://w3id.org/emmo/chemicalsubstance#substance_f4dffee2_c642_4114_a748_5e93b3908380
 :substance_f4dffee2_c642_4114_a748_5e93b3908380 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/15975531" ;
@@ -7213,7 +7213,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIIBistrifluoromethanesulfonylimide"@en .
 
 
-###  http://emmo.info/substance#substance_f4eacd3e_ec96_4448_a090_2f7f18ddda0e
+###  https://w3id.org/emmo/chemicalsubstance#substance_f4eacd3e_ec96_4448_a090_2f7f18ddda0e
 :substance_f4eacd3e_ec96_4448_a090_2f7f18ddda0e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q883666"@en ;
@@ -7226,7 +7226,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIIPhosphate"@en .
 
 
-###  http://emmo.info/substance#substance_f57d5d5e_15a4_40de_a8d1_c3504f3c8827
+###  https://w3id.org/emmo/chemicalsubstance#substance_f57d5d5e_15a4_40de_a8d1_c3504f3c8827
 :substance_f57d5d5e_15a4_40de_a8d1_c3504f3c8827 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2453066"@en ;
@@ -7241,13 +7241,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Triglyme"@en .
 
 
-###  http://emmo.info/substance#substance_f5b930f9_2f95_4268_993c_ff6b57ae7691
+###  https://w3id.org/emmo/chemicalsubstance#substance_f5b930f9_2f95_4268_993c_ff6b57ae7691
 :substance_f5b930f9_2f95_4268_993c_ff6b57ae7691 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cc155ed5_c60c_4d9f_bfad_fbf6b7c77e57 ;
                                                 skos:prefLabel "StrongAcid"@en .
 
 
-###  http://emmo.info/substance#substance_f6460d8d_5d5e_452d_8853_bdec3796a90e
+###  https://w3id.org/emmo/chemicalsubstance#substance_f6460d8d_5d5e_452d_8853_bdec3796a90e
 :substance_f6460d8d_5d5e_452d_8853_bdec3796a90e rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72515436"@en ;
@@ -7259,7 +7259,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TFP"@en .
 
 
-###  http://emmo.info/substance#substance_f6eb3754_2ccb_406d_b407_c989a7e1b4f9
+###  https://w3id.org/emmo/chemicalsubstance#substance_f6eb3754_2ccb_406d_b407_c989a7e1b4f9
 :substance_f6eb3754_2ccb_406d_b407_c989a7e1b4f9 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q27261538"@en ;
@@ -7271,7 +7271,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "DipropylSulfone"@en .
 
 
-###  http://emmo.info/substance#substance_f70feadf_0251_4a46_8716_ee6acb435455
+###  https://w3id.org/emmo/chemicalsubstance#substance_f70feadf_0251_4a46_8716_ee6acb435455
 :substance_f70feadf_0251_4a46_8716_ee6acb435455 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q48318"@en ;
@@ -7284,7 +7284,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Urea"@en .
 
 
-###  http://emmo.info/substance#substance_f7525766_90cf_43e9_8932_7cb3b14f676f
+###  https://w3id.org/emmo/chemicalsubstance#substance_f7525766_90cf_43e9_8932_7cb3b14f676f
 :substance_f7525766_90cf_43e9_8932_7cb3b14f676f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4ad18bbe_6478_4009_8f80_b669a6ae3f7a ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q418812"@en ;
@@ -7297,7 +7297,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IridiumDioxide"@en .
 
 
-###  http://emmo.info/substance#substance_f7a11bfc_4cb1_45a7_8248_8e2d534884d3
+###  https://w3id.org/emmo/chemicalsubstance#substance_f7a11bfc_4cb1_45a7_8248_8e2d534884d3
 :substance_f7a11bfc_4cb1_45a7_8248_8e2d534884d3 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2468"@en ;
@@ -7310,13 +7310,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "HydrogenFluoride"@en .
 
 
-###  http://emmo.info/substance#substance_f7d13311_6dd1_422c_b32b_b55fd9e77145
+###  https://w3id.org/emmo/chemicalsubstance#substance_f7d13311_6dd1_422c_b32b_b55fd9e77145
 :substance_f7d13311_6dd1_422c_b32b_b55fd9e77145 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "CopperOxideCompound"@en .
 
 
-###  http://emmo.info/substance#substance_f8954854_f303_4a2e_9e81_ff1a20623c96
+###  https://w3id.org/emmo/chemicalsubstance#substance_f8954854_f303_4a2e_9e81_ff1a20623c96
 :substance_f8954854_f303_4a2e_9e81_ff1a20623c96 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2091170"@en ;
@@ -7329,7 +7329,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumNitrite"@en .
 
 
-###  http://emmo.info/substance#substance_f8d50782_11fa_4188_ba55_d043d2eb597d
+###  https://w3id.org/emmo/chemicalsubstance#substance_f8d50782_11fa_4188_ba55_d043d2eb597d
 :substance_f8d50782_11fa_4188_ba55_d043d2eb597d rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -7342,7 +7342,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Titanium"@en .
 
 
-###  http://emmo.info/substance#substance_f8ed464a_16e3_491e_b366_6c933e689fa5
+###  https://w3id.org/emmo/chemicalsubstance#substance_f8ed464a_16e3_491e_b366_6c933e689fa5
 :substance_f8ed464a_16e3_491e_b366_6c933e689fa5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411436"@en ;
@@ -7355,7 +7355,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIISulfide"@en .
 
 
-###  http://emmo.info/substance#substance_f92b3948_72a5_4662_acf7_5d8dd64e85de
+###  https://w3id.org/emmo/chemicalsubstance#substance_f92b3948_72a5_4662_acf7_5d8dd64e85de
 :substance_f92b3948_72a5_4662_acf7_5d8dd64e85de rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -7368,7 +7368,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Nickel"@en .
 
 
-###  http://emmo.info/substance#substance_f96ceacb_2808_4c4d_925c_d28086c8a2e1
+###  https://w3id.org/emmo/chemicalsubstance#substance_f96ceacb_2808_4c4d_925c_d28086c8a2e1
 :substance_f96ceacb_2808_4c4d_925c_d28086c8a2e1 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -7381,7 +7381,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Palladium"@en .
 
 
-###  http://emmo.info/substance#substance_f9b2b3e1_058c_46c5_9004_32b23fd728be
+###  https://w3id.org/emmo/chemicalsubstance#substance_f9b2b3e1_058c_46c5_9004_32b23fd728be
 :substance_f9b2b3e1_058c_46c5_9004_32b23fd728be rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409179"@en ;
@@ -7394,7 +7394,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumNitrite"@en .
 
 
-###  http://emmo.info/substance#substance_fa20cd88_2a7d_4820_9f22_d55e1f592b5c
+###  https://w3id.org/emmo/chemicalsubstance#substance_fa20cd88_2a7d_4820_9f22_d55e1f592b5c
 :substance_fa20cd88_2a7d_4820_9f22_d55e1f592b5c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q414680"@en ;
@@ -7407,7 +7407,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIIFluoride"@en .
 
 
-###  http://emmo.info/substance#substance_fabdb93c_dc23_40a9_ae83_8981d2bea07e
+###  https://w3id.org/emmo/chemicalsubstance#substance_fabdb93c_dc23_40a9_ae83_8981d2bea07e
 :substance_fabdb93c_dc23_40a9_ae83_8981d2bea07e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f5b930f9_2f95_4268_993c_ff6b57ae7691 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q83320"@en ;
@@ -7420,7 +7420,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NitricAcid"@en .
 
 
-###  http://emmo.info/substance#substance_fadf36f3_166e_4a2d_a933_7072e6bc578c
+###  https://w3id.org/emmo/chemicalsubstance#substance_fadf36f3_166e_4a2d_a933_7072e6bc578c
 :substance_fadf36f3_166e_4a2d_a933_7072e6bc578c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q420413"@en ;
@@ -7433,7 +7433,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumBromide"@en .
 
 
-###  http://emmo.info/substance#substance_fbefcf90_c797_4d2f_a072_3d603e42ca9a
+###  https://w3id.org/emmo/chemicalsubstance#substance_fbefcf90_c797_4d2f_a072_3d603e42ca9a
 :substance_fbefcf90_c797_4d2f_a072_3d603e42ca9a rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
@@ -7447,7 +7447,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ThionylChloride"@en .
 
 
-###  http://emmo.info/substance#substance_fc4220a5_3f91_4a60_83c3_4c1be988c2f1
+###  https://w3id.org/emmo/chemicalsubstance#substance_fc4220a5_3f91_4a60_83c3_4c1be988c2f1
 :substance_fc4220a5_3f91_4a60_83c3_4c1be988c2f1 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a4a5b239_d88e_4e03_a763_0bf2a3dd0f47 ;
@@ -7461,7 +7461,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Barium"@en .
 
 
-###  http://emmo.info/substance#substance_fc7a3d86_8399_4afa_9d12_f5265ec6ec0e
+###  https://w3id.org/emmo/chemicalsubstance#substance_fc7a3d86_8399_4afa_9d12_f5265ec6ec0e
 :substance_fc7a3d86_8399_4afa_9d12_f5265ec6ec0e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q425231"@en ;
@@ -7474,13 +7474,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIIBromide"@en .
 
 
-###  http://emmo.info/substance#substance_fc93282d_cb35_4bab_81a8_78689ae59e5f
+###  https://w3id.org/emmo/chemicalsubstance#substance_fc93282d_cb35_4bab_81a8_78689ae59e5f
 :substance_fc93282d_cb35_4bab_81a8_78689ae59e5f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_edae7b22_461b_432b_b737_3c93feb69b0e ;
                                                 skos:prefLabel "AlkalineEarthMetalSaltCompound"@en .
 
 
-###  http://emmo.info/substance#substance_fcc8de17_cb4d_409e_93ef_4970df535743
+###  https://w3id.org/emmo/chemicalsubstance#substance_fcc8de17_cb4d_409e_93ef_4970df535743
 :substance_fcc8de17_cb4d_409e_93ef_4970df535743 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72444806"@en ;
@@ -7492,7 +7492,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumTriflate"@en .
 
 
-###  http://emmo.info/substance#substance_fd189d24_5434_4f93_b5a9_4796e67d88f1
+###  https://w3id.org/emmo/chemicalsubstance#substance_fd189d24_5434_4f93_b5a9_4796e67d88f1
 :substance_fd189d24_5434_4f93_b5a9_4796e67d88f1 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q906306"@en ;
@@ -7505,7 +7505,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumPerchlorate"@en .
 
 
-###  http://emmo.info/substance#substance_fd587814_4556_4909_8690_9d539d612e2a
+###  https://w3id.org/emmo/chemicalsubstance#substance_fd587814_4556_4909_8690_9d539d612e2a
 :substance_fd587814_4556_4909_8690_9d539d612e2a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_d9f73522_049b_4542_909d_d7daefa9613b ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q174727"@en ;
@@ -7518,7 +7518,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MercuryIIOxide"@en .
 
 
-###  http://emmo.info/substance#substance_fdc7f434_0f3e_423d_9689_d1be939b5537
+###  https://w3id.org/emmo/chemicalsubstance#substance_fdc7f434_0f3e_423d_9689_d1be939b5537
 :substance_fdc7f434_0f3e_423d_9689_d1be939b5537 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7e716191_b301_4d63_bb6b_93323ffe51bf ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q145421"@en ;
@@ -7531,7 +7531,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Polyacrylonitrile"@en .
 
 
-###  http://emmo.info/substance#substance_fdfcbe9c_164d_4e11_b547_519a1abed8d0
+###  https://w3id.org/emmo/chemicalsubstance#substance_fdfcbe9c_164d_4e11_b547_519a1abed8d0
 :substance_fdfcbe9c_164d_4e11_b547_519a1abed8d0 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -7545,14 +7545,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "EthylAcetate"@en .
 
 
-###  http://emmo.info/substance#substance_fe5452de_6d49_4f60_9a15_a022bb5219a2
+###  https://w3id.org/emmo/chemicalsubstance#substance_fe5452de_6d49_4f60_9a15_a022bb5219a2
 :substance_fe5452de_6d49_4f60_9a15_a022bb5219a2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 skos:altLabel "Ca(FSI)2"@en ;
                                                 skos:prefLabel "CalciumBisfluorosulfonylimide"@en .
 
 
-###  http://emmo.info/substance#substance_feb95008_db3a_4506_b7ff_6263befa0d64
+###  https://w3id.org/emmo/chemicalsubstance#substance_feb95008_db3a_4506_b7ff_6263befa0d64
 :substance_feb95008_db3a_4506_b7ff_6263befa0d64 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q213580"@en ;
@@ -7564,7 +7564,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PyruvicAcid"@en .
 
 
-###  http://emmo.info/substance#substance_fec97ca4_73a1_4b8f_b7ae_eddc88498829
+###  https://w3id.org/emmo/chemicalsubstance#substance_fec97ca4_73a1_4b8f_b7ae_eddc88498829
 :substance_fec97ca4_73a1_4b8f_b7ae_eddc88498829 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q408805"@en ;
@@ -7577,7 +7577,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIIIodide"@en .
 
 
-###  http://emmo.info/substance#substance_fed5b5ee_de69_405d_9ce1_d6aaf89017db
+###  https://w3id.org/emmo/chemicalsubstance#substance_fed5b5ee_de69_405d_9ce1_d6aaf89017db
 :substance_fed5b5ee_de69_405d_9ce1_d6aaf89017db rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q259311"@en ;
@@ -7590,7 +7590,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumBromide"@en .
 
 
-###  http://emmo.info/substance#substance_ff0f6cb9_d9e7_4a9e_848f_02200eed0cf7
+###  https://w3id.org/emmo/chemicalsubstance#substance_ff0f6cb9_d9e7_4a9e_848f_02200eed0cf7
 :substance_ff0f6cb9_d9e7_4a9e_848f_02200eed0cf7 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q414613"@en ;
@@ -7603,7 +7603,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumBromide"@en .
 
 
-###  http://emmo.info/substance#substance_ff193c19_3ddf_4c61_96f1_322254c3980e
+###  https://w3id.org/emmo/chemicalsubstance#substance_ff193c19_3ddf_4c61_96f1_322254c3980e
 :substance_ff193c19_3ddf_4c61_96f1_322254c3980e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q422930"@en ;
@@ -7616,7 +7616,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumChloride"@en .
 
 
-###  http://emmo.info/substance#substance_ff2979a3_06b8_416c_bc49_208d96f25fa4
+###  https://w3id.org/emmo/chemicalsubstance#substance_ff2979a3_06b8_416c_bc49_208d96f25fa4
 :substance_ff2979a3_06b8_416c_bc49_208d96f25fa4 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q416623"@en ;
@@ -7629,7 +7629,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIIFluoride"@en .
 
 
-###  http://emmo.info/substance#substance_ff5b9c8c_3fb0_4575_9ab8_23ebd9116294
+###  https://w3id.org/emmo/chemicalsubstance#substance_ff5b9c8c_3fb0_4575_9ab8_23ebd9116294
 :substance_ff5b9c8c_3fb0_4575_9ab8_23ebd9116294 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_b978912b_19ef_4d46_8c91_2e3578b12670 ;

--- a/chemicalsubstance.ttl
+++ b/chemicalsubstance.ttl
@@ -1,4 +1,4 @@
-@prefix : <https://w3id.org/emmo/chemicalsubstance#> .
+@prefix : <https://w3id.org/emmo/domain/chemicalsubstance#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix xml: <http://www.w3.org/XML/1998/namespace> .
@@ -8,15 +8,15 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix annotations: <http://emmo.info/emmo/top/annotations#> .
-@base <http://emmo.info/chemicalsubstance/chemicalsubstance> .
+@base <https://w3id.org/emmo/domain/chemicalsubstance/chemicalsubstance> .
 
-<http://emmo.info/chemicalsubstance/chemicalsubstance> rdf:type owl:Ontology ;
-                                                        owl:versionIRI <http://emmo.info/chemicalsubstance/0.1.0/chemicalsubstance> ;
+<https://w3id.org/emmo/domain/chemicalsubstance/chemicalsubstance> rdf:type owl:Ontology ;
+                                                        owl:versionIRI <https://w3id.org/emmo/domain/chemicalsubstance/0.2.0/chemicalsubstance> ;
                                                         owl:imports <http://emmo.info/emmo/1.0.0-beta5> ;
                                                         dcterms:abstract "This ontology provides terms for chemical substances that can be referenced and re-used other resources."@en ;
                                                         dcterms:contributor "Jesper Friis" ;
                                                         dcterms:creator "Simon Clark" ;
-                                                        owl:versionInfo "0.1.0" .
+                                                        owl:versionInfo "0.2.0" .
 
 #################################################################
 #    Annotation properties
@@ -56,26 +56,26 @@ dcterms:source rdf:type owl:AnnotationProperty .
 #    Classes
 #################################################################
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_0001e895_e74b_438f_b47f_b52f33d68331
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_0001e895_e74b_438f_b47f_b52f33d68331
 :substance_0001e895_e74b_438f_b47f_b52f33d68331 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_fc93282d_cb35_4bab_81a8_78689ae59e5f ;
                                                 skos:prefLabel "MagnesiumSaltCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_001ca83b_5372_4d77_a836_4d48074b7e63
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_001ca83b_5372_4d77_a836_4d48074b7e63
 :substance_001ca83b_5372_4d77_a836_4d48074b7e63 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "TitaniumOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_00db9ba1_7259_4180_a82e_7ed4dafc29a9
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_00db9ba1_7259_4180_a82e_7ed4dafc29a9
 :substance_00db9ba1_7259_4180_a82e_7ed4dafc29a9 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 skos:altLabel "Mg(PF6)2"@en ;
                                                 skos:prefLabel "MagnesiumHexafluorophosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_0111ec52_b838_49ab_a24b_884aaa3f54e8
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_0111ec52_b838_49ab_a24b_884aaa3f54e8
 :substance_0111ec52_b838_49ab_a24b_884aaa3f54e8 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_3540fb20_f719_42eb_ad0c_112ffedb7c6d ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q196661"@en ;
@@ -88,13 +88,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CadmiumOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_0111fe83_2d6c_4df0_9fd3_500ddda7242c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_0111fe83_2d6c_4df0_9fd3_500ddda7242c
 :substance_0111fe83_2d6c_4df0_9fd3_500ddda7242c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_61c88366_7689_4814_b0c5_1f53aef1eebd ;
                                                 skos:prefLabel "GalliumOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_012d4091_06bc_4089_bba4_b832200e69cd
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_012d4091_06bc_4089_bba4_b832200e69cd
 :substance_012d4091_06bc_4089_bba4_b832200e69cd rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411260"@en ;
@@ -107,7 +107,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIICarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_0139937b_2724_4864_84fb_f14bcfb83538
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_0139937b_2724_4864_84fb_f14bcfb83538
 :substance_0139937b_2724_4864_84fb_f14bcfb83538 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/129656524" ;
@@ -118,13 +118,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumManganeseOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_015116fe_94ca_4be5_9d14_9d9457a47a72
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_015116fe_94ca_4be5_9d14_9d9457a47a72
 :substance_015116fe_94ca_4be5_9d14_9d9457a47a72 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_edae7b22_461b_432b_b737_3c93feb69b0e ;
                                                 skos:prefLabel "TransitionMetalSaltCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_02172b42_6e67_439c_93f4_42e7949268ce
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_02172b42_6e67_439c_93f4_42e7949268ce
 :substance_02172b42_6e67_439c_93f4_42e7949268ce rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q114346676"@en ;
@@ -136,7 +136,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumBistrifluoromethanesulfonylimide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_0238c3cb_706f_4c5a_84e3_0738e16264bb
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_0238c3cb_706f_4c5a_84e3_0738e16264bb
 :substance_0238c3cb_706f_4c5a_84e3_0738e16264bb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q447553"@en ;
@@ -148,7 +148,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumChlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_02ec30fa_cbca_4988_8c6b_6ec9f0cd138c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_02ec30fa_cbca_4988_8c6b_6ec9f0cd138c
 :substance_02ec30fa_cbca_4988_8c6b_6ec9f0cd138c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q422837"@en ;
@@ -161,7 +161,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIIAcetate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_032dde57_9fb4_4cd4_b212_282ff72ea152
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_032dde57_9fb4_4cd4_b212_282ff72ea152
 :substance_032dde57_9fb4_4cd4_b212_282ff72ea152 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q161233"@en ;
@@ -174,13 +174,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "FormicAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5
 :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_015116fe_94ca_4be5_9d14_9d9457a47a72 ;
                                                 skos:prefLabel "LeadSaltCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_0391f63f_9ab8_4b33_a4c5_47591a89de72
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_0391f63f_9ab8_4b33_a4c5_47591a89de72
 :substance_0391f63f_9ab8_4b33_a4c5_47591a89de72 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q324628"@en ;
@@ -192,7 +192,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AcrylicAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_046a3fb1_cd54_4014_afd0_908a8ad1da5e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_046a3fb1_cd54_4014_afd0_908a8ad1da5e
 :substance_046a3fb1_cd54_4014_afd0_908a8ad1da5e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q79739"@en ;
@@ -207,7 +207,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "GammaButyrolactone"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_046acf7e_3390_484c_8c7e_7cf2a331fb3b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_046acf7e_3390_484c_8c7e_7cf2a331fb3b
 :substance_046acf7e_3390_484c_8c7e_7cf2a331fb3b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q417121"@en ;
@@ -220,7 +220,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIIFluoride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_0470d73a_ea51_4505_b164_0c090bf0382b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_0470d73a_ea51_4505_b164_0c090bf0382b
 :substance_0470d73a_ea51_4505_b164_0c090bf0382b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4737377"@en ;
@@ -233,7 +233,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumCarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_04a7bd93_0a55_444b_a28e_33b01ee0bc4e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_04a7bd93_0a55_444b_a28e_33b01ee0bc4e
 :substance_04a7bd93_0a55_444b_a28e_33b01ee0bc4e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q286064"@en ;
@@ -246,7 +246,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIINitrate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_04ad7fec_b260_4d25_9c6e_47711c0f8a46
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_04ad7fec_b260_4d25_9c6e_47711c0f8a46
 :substance_04ad7fec_b260_4d25_9c6e_47711c0f8a46 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "http://127.0.0.1:5000/compounds/23290296"@en ;
@@ -258,14 +258,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MOEMC"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_05b11934_6a3e_4434_855b_111aced0a6be
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_05b11934_6a3e_4434_855b_111aced0a6be
 :substance_05b11934_6a3e_4434_855b_111aced0a6be rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 skos:altLabel "Ba(TFSI)2"@en ;
                                                 skos:prefLabel "BariumBistrifluoromethanesulfonylimide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_08695cfe_3dfa_4b17_9f09_13e6f90e3875
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_08695cfe_3dfa_4b17_9f09_13e6f90e3875
 :substance_08695cfe_3dfa_4b17_9f09_13e6f90e3875 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/101611500" ;
@@ -276,7 +276,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIINitrite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_09338922_833a_406c_be2c_4098980cabc3
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_09338922_833a_406c_be2c_4098980cabc3
 :substance_09338922_833a_406c_be2c_4098980cabc3 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4096881"@en ;
@@ -289,13 +289,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIIBromide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_094f08bc_90ea_4118_b136_47e61e495ab5
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_094f08bc_90ea_4118_b136_47e61e495ab5
 :substance_094f08bc_90ea_4118_b136_47e61e495ab5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_015116fe_94ca_4be5_9d14_9d9457a47a72 ;
                                                 skos:prefLabel "CopperSaltCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_0952b0ae_0067_4b42_812a_abb68c95a6f8
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_0952b0ae_0067_4b42_812a_abb68c95a6f8
 :substance_0952b0ae_0067_4b42_812a_abb68c95a6f8 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/2734307" ;
@@ -306,7 +306,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumTriflate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_0993cbab_ff7f_4ec3_8a6c_cd67497d54d9
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_0993cbab_ff7f_4ec3_8a6c_cd67497d54d9
 :substance_0993cbab_ff7f_4ec3_8a6c_cd67497d54d9 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -319,14 +319,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Copper"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_09aa1409_b244_4d5e_a6ed_c94bdff60e42
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_09aa1409_b244_4d5e_a6ed_c94bdff60e42
 :substance_09aa1409_b244_4d5e_a6ed_c94bdff60e42 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 skos:altLabel "Mn(ClO3)2"@en ;
                                                 skos:prefLabel "ManganeseIIChlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_09c627db_bca7_4a25_9233_90af4e22505e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_09c627db_bca7_4a25_9233_90af4e22505e
 :substance_09c627db_bca7_4a25_9233_90af4e22505e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_878a0e2f_12ba_484e_8197_75e57139d207 ,
                                                                 :substance_961f7671_8708_4ce3_9c7d_79444adba9c0 ;
@@ -340,7 +340,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Methanol"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_09e14ca2_f909_40cc_ba93_e1a149938abc
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_09e14ca2_f909_40cc_ba93_e1a149938abc
 :substance_09e14ca2_f909_40cc_ba93_e1a149938abc rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bed1a22c_8b61_467a_86a0_d24c7b910653 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q182849"@en ;
@@ -353,7 +353,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumHydroxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_09e44ba7_e928_4aa8_aa50_484742e6965c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_09e44ba7_e928_4aa8_aa50_484742e6965c
 :substance_09e44ba7_e928_4aa8_aa50_484742e6965c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72482882"@en ;
@@ -365,7 +365,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIITetrafluoroborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_0a5cb747_60cf_4929_a54a_712c54b49f3b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_0a5cb747_60cf_4929_a54a_712c54b49f3b
 :substance_0a5cb747_60cf_4929_a54a_712c54b49f3b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_6c0cc397_d8c4_4473_a09f_1e5de568e0dd ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q764245"@en ;
@@ -373,14 +373,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CarbonBlack"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_0a6ddace_69a9_43af_8cb1_bf1fcfaaea67
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_0a6ddace_69a9_43af_8cb1_bf1fcfaaea67
 :substance_0a6ddace_69a9_43af_8cb1_bf1fcfaaea67 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 skos:altLabel "NaBOP"@en ;
                                                 skos:prefLabel "SodiumBisoxalatophosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_0aae472b_b322_43c4_991f_e4ec88f52f3e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_0aae472b_b322_43c4_991f_e4ec88f52f3e
 :substance_0aae472b_b322_43c4_991f_e4ec88f52f3e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72482889"@en ;
@@ -392,7 +392,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIITriflate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_0bdf0bb9_41fc_455d_af11_a249e24acdf6
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_0bdf0bb9_41fc_455d_af11_a249e24acdf6
 :substance_0bdf0bb9_41fc_455d_af11_a249e24acdf6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/13710615" ;
@@ -402,13 +402,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumCobaltPhosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_0dcf209c_6455_4305_9714_fec548742c6a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_0dcf209c_6455_4305_9714_fec548742c6a
 :substance_0dcf209c_6455_4305_9714_fec548742c6a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "PalladiumOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_0deb4fe8_b0c0_4e3f_8848_64435e5c0771
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_0deb4fe8_b0c0_4e3f_8848_64435e5c0771
 :substance_0deb4fe8_b0c0_4e3f_8848_64435e5c0771 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2583808"@en ;
@@ -421,7 +421,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumHexafluorophosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_0e21b44e_5749_4b19_9d79_d8b70df1cdc6
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_0e21b44e_5749_4b19_9d79_d8b70df1cdc6
 :substance_0e21b44e_5749_4b19_9d79_d8b70df1cdc6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_de038959_9251_48d1_a141_3684f14d957f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407125"@en ;
@@ -434,7 +434,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumHydroxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_0e235e95_739d_443a_ad4b_97ef1edb9c89
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_0e235e95_739d_443a_ad4b_97ef1edb9c89
 :substance_0e235e95_739d_443a_ad4b_97ef1edb9c89 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2234483"@en ;
@@ -448,7 +448,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Dioxolane"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_0f29d712_f329_4b17_abeb_5df9bf4fb321
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_0f29d712_f329_4b17_abeb_5df9bf4fb321
 :substance_0f29d712_f329_4b17_abeb_5df9bf4fb321 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -461,7 +461,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Technetium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1
 :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q146505" ;
@@ -478,7 +478,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
  ] .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_1285bd02_b0c1_45cb_8895_6ae6517f86a1
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_1285bd02_b0c1_45cb_8895_6ae6517f86a1
 :substance_1285bd02_b0c1_45cb_8895_6ae6517f86a1 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q422956"@en ;
@@ -490,7 +490,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PropionicAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_12f3fc79_fc8f_44a1_8736_945e03392abe
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_12f3fc79_fc8f_44a1_8736_945e03392abe
 :substance_12f3fc79_fc8f_44a1_8736_945e03392abe rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/15976041" ;
@@ -501,7 +501,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIIBistrifluoromethanesulfonylimide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_13eaf787_000e_44f8_b939_332101e81dd2
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_13eaf787_000e_44f8_b939_332101e81dd2
 :substance_13eaf787_000e_44f8_b939_332101e81dd2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q60568753"@en ;
@@ -514,19 +514,19 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIIPhosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_155e894b_66de_4cda_9dbe_adbeca7d8102
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_155e894b_66de_4cda_9dbe_adbeca7d8102
 :substance_155e894b_66de_4cda_9dbe_adbeca7d8102 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "TinOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_15d08ff9_7685_4020_8481_d9c9b0052176
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_15d08ff9_7685_4020_8481_d9c9b0052176
 :substance_15d08ff9_7685_4020_8481_d9c9b0052176 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ;
                                                 skos:prefLabel "MixedMetalOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_16864b33_aa8e_451d_ad8e_b0af5f18769a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_16864b33_aa8e_451d_ad8e_b0af5f18769a
 :substance_16864b33_aa8e_451d_ad8e_b0af5f18769a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q278332"@en ;
@@ -540,7 +540,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Tetrahydrofuran"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_16d7c7a6_56ef_429b_9ce8_cd911410d083
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_16d7c7a6_56ef_429b_9ce8_cd911410d083
 :substance_16d7c7a6_56ef_429b_9ce8_cd911410d083 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/203099" ;
@@ -551,7 +551,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumTetrafluoroborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_177b95f8_2816_43de_94bb_1a1054c45e32
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_177b95f8_2816_43de_94bb_1a1054c45e32
 :substance_177b95f8_2816_43de_94bb_1a1054c45e32 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_8e5448fc_1916_4afb_9fd9_2489797f6922 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204820"@en ;
@@ -561,7 +561,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincHydroxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_17c30663_ccc8_45b0_b713_9bd095e20ebd
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_17c30663_ccc8_45b0_b713_9bd095e20ebd
 :substance_17c30663_ccc8_45b0_b713_9bd095e20ebd rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q15628085"@en ;
@@ -574,7 +574,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIIPerchlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_191c3c02_4930_44d4_bf20_0d79ed41f8c5
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_191c3c02_4930_44d4_bf20_0d79ed41f8c5
 :substance_191c3c02_4930_44d4_bf20_0d79ed41f8c5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/18760923" ;
@@ -586,7 +586,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIISulfite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_19292fbf_8a09_45a0_b807_f643253a333c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_19292fbf_8a09_45a0_b807_f643253a333c
 :substance_19292fbf_8a09_45a0_b807_f643253a333c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f5b930f9_2f95_4268_993c_ff6b57ae7691 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q138809"@en ;
@@ -599,7 +599,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ChloricAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_1988f19c_c06b_44ab_817e_dd23b9dfd9d5
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_1988f19c_c06b_44ab_817e_dd23b9dfd9d5
 :substance_1988f19c_c06b_44ab_817e_dd23b9dfd9d5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0111fe83_2d6c_4df0_9fd3_500ddda7242c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q419487"@en ;
@@ -612,7 +612,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "GalliumOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_19f88cb6_57a8_4111_9d73_6b58dce0ba76
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_19f88cb6_57a8_4111_9d73_6b58dce0ba76
 :substance_19f88cb6_57a8_4111_9d73_6b58dce0ba76 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204713"@en ;
@@ -625,7 +625,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincCyanide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_1b31f3bb_1c1b_40e2_8d0f_0e21abe237e7
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_1b31f3bb_1c1b_40e2_8d0f_0e21abe237e7
 :substance_1b31f3bb_1c1b_40e2_8d0f_0e21abe237e7 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q27861942"@en ;
@@ -638,14 +638,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumAcetate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_1be34841_81f7_4216_8290_6bd75361a1c9
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_1be34841_81f7_4216_8290_6bd75361a1c9
 :substance_1be34841_81f7_4216_8290_6bd75361a1c9 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 skos:altLabel "NaTFOB"@en ;
                                                 skos:prefLabel "SodiumTrifluoromethanesulfonyloxalatoborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_1c24293c_3a09_4084_a6bb_0db9fae5e786
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_1c24293c_3a09_4084_a6bb_0db9fae5e786
 :substance_1c24293c_3a09_4084_a6bb_0db9fae5e786 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q28457468"@en ;
@@ -658,7 +658,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Tris222TrifluoroethylBorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_1d8e9a99_b998_47e6_98a7_a6efd8dab9ce
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_1d8e9a99_b998_47e6_98a7_a6efd8dab9ce
 :substance_1d8e9a99_b998_47e6_98a7_a6efd8dab9ce rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_6c0cc397_d8c4_4473_a09f_1e5de568e0dd ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1997"@en ;
@@ -670,7 +670,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CarbonDioxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_1dd8fd65_919b_40d1_a78c_9409b28e323e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_1dd8fd65_919b_40d1_a78c_9409b28e323e
 :substance_1dd8fd65_919b_40d1_a78c_9409b28e323e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q414189"@en ;
@@ -685,7 +685,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MethylAcetate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_1dfa4556_49d2_494c_971d_bd193219e9b2
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_1dfa4556_49d2_494c_971d_bd193219e9b2
 :substance_1dfa4556_49d2_494c_971d_bd193219e9b2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411337"@en ;
@@ -698,7 +698,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIISulfate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_1e30dcc6_b1c7_4fe9_8f36_1dd427c78a93
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_1e30dcc6_b1c7_4fe9_8f36_1dd427c78a93
 :substance_1e30dcc6_b1c7_4fe9_8f36_1dd427c78a93 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q20670642"@en ;
@@ -710,14 +710,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincSulfite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_1e5c69b2_6dac_44b6_a24e_6170b516cf2c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_1e5c69b2_6dac_44b6_a24e_6170b516cf2c
 :substance_1e5c69b2_6dac_44b6_a24e_6170b516cf2c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 skos:altLabel "Ca(BOP)2"@en ;
                                                 skos:prefLabel "CalciumBisoxalatophosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_20004d19_02cf_4667_a09f_b5c595b44b1f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_20004d19_02cf_4667_a09f_b5c595b44b1f
 :substance_20004d19_02cf_4667_a09f_b5c595b44b1f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/2769656" ;
@@ -728,7 +728,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "FluoroethyleneCarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_20319b23_0673_45de_9b12_794813d948a9
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_20319b23_0673_45de_9b12_794813d948a9
 :substance_20319b23_0673_45de_9b12_794813d948a9 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a9a6507f_9c61_44d3_bd86_f1ebf763e150 ;
@@ -741,7 +741,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Arsenic"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_210edf30_ad63_438c_97db_f817942db49b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_210edf30_ad63_438c_97db_f817942db49b
 :substance_210edf30_ad63_438c_97db_f817942db49b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7e716191_b301_4d63_bb6b_93323ffe51bf ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q146429"@en ;
@@ -754,7 +754,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StyreneButadiene"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_21954b0b_c05c_42db_b276_3a931d8aabb1
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_21954b0b_c05c_42db_b276_3a931d8aabb1
 :substance_21954b0b_c05c_42db_b276_3a931d8aabb1 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411496"@en ;
@@ -769,7 +769,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Dimethoxymethane"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_22796803_c3b7_4e24_b6f9_7f65d453b01a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_22796803_c3b7_4e24_b6f9_7f65d453b01a
 :substance_22796803_c3b7_4e24_b6f9_7f65d453b01a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f7d13311_6dd1_422c_b32b_b55fd9e77145 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407709"@en ;
@@ -782,7 +782,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_22a9ed4c_0e7b_4f40_93e5_6aa9ecda1fff
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_22a9ed4c_0e7b_4f40_93e5_6aa9ecda1fff
 :substance_22a9ed4c_0e7b_4f40_93e5_6aa9ecda1fff rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409373"@en ;
@@ -795,7 +795,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "GlycolicAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_23145a95_d51a_471c_8f5c_ec1a970b3798
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_23145a95_d51a_471c_8f5c_ec1a970b3798
 :substance_23145a95_d51a_471c_8f5c_ec1a970b3798 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1674310"@en ;
@@ -808,7 +808,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumAcetate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_231feb61_4200_4bc7_b060_02b51ab13ee2
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_231feb61_4200_4bc7_b060_02b51ab13ee2
 :substance_231feb61_4200_4bc7_b060_02b51ab13ee2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q410203"@en ;
@@ -821,7 +821,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumPerchlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_244fbc5c_41d5_42aa_b078_019cb0b2f3b7
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_244fbc5c_41d5_42aa_b078_019cb0b2f3b7
 :substance_244fbc5c_41d5_42aa_b078_019cb0b2f3b7 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4321583"@en ;
@@ -834,7 +834,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIINitrate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_24bb590f_86c4_4fd9_ac4e_ef89a43d0fb1
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_24bb590f_86c4_4fd9_ac4e_ef89a43d0fb1
 :substance_24bb590f_86c4_4fd9_ac4e_ef89a43d0fb1 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_de038959_9251_48d1_a141_3684f14d957f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q410563"@en ;
@@ -847,7 +847,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ChromiumHydroxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_250fa43e_1f26_4ed8_b787_91a2325a8e7b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_250fa43e_1f26_4ed8_b787_91a2325a8e7b
 :substance_250fa43e_1f26_4ed8_b787_91a2325a8e7b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f7d13311_6dd1_422c_b32b_b55fd9e77145 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421787"@en ;
@@ -860,7 +860,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_25f6ff4c_53ad_4837_97c4_aa6f06099bb5
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_25f6ff4c_53ad_4837_97c4_aa6f06099bb5
 :substance_25f6ff4c_53ad_4837_97c4_aa6f06099bb5 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -873,7 +873,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Platinum"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_26452118_db69_4a2f_a862_2cebe1f6c85f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_26452118_db69_4a2f_a862_2cebe1f6c85f
 :substance_26452118_db69_4a2f_a862_2cebe1f6c85f rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/102470862" ;
@@ -883,7 +883,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BPFPB"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_26727c25_d619_4c2b_8699_a79be9c07bd5
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_26727c25_d619_4c2b_8699_a79be9c07bd5
 :substance_26727c25_d619_4c2b_8699_a79be9c07bd5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q390305"@en ;
@@ -896,14 +896,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumIodide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_27696fcd_aa90_44b9_816a_c19400f0ab9a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_27696fcd_aa90_44b9_816a_c19400f0ab9a
 :substance_27696fcd_aa90_44b9_816a_c19400f0ab9a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 skos:altLabel "Mg(BOB)2"@en ;
                                                 skos:prefLabel "MagnesiumBisoxalatoborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_2773ee9b_cee9_4367_8b81_4ce6265d411a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_2773ee9b_cee9_4367_8b81_4ce6265d411a
 :substance_2773ee9b_cee9_4367_8b81_4ce6265d411a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1392795"@en ;
@@ -916,7 +916,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumChlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_27b3d761_128f_4480_8d84_498160a3dfac
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_27b3d761_128f_4480_8d84_498160a3dfac
 :substance_27b3d761_128f_4480_8d84_498160a3dfac rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1910594"@en ;
@@ -929,7 +929,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumHexafluorophosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_27f50595_4b06_478b_8a93_877ea00c943a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_27f50595_4b06_478b_8a93_877ea00c943a
 :substance_27f50595_4b06_478b_8a93_877ea00c943a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c7bab57c_23c4_41d7_b2dc_497683fc82db ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409279"@en ;
@@ -942,13 +942,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "RhodiumIVOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_28754642_a1ed_4f39_8b00_2c7857336bab
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_28754642_a1ed_4f39_8b00_2c7857336bab
 :substance_28754642_a1ed_4f39_8b00_2c7857336bab rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "ZincOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_28899817_2002_42d8_92bf_b43d2cf7b4c6
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_28899817_2002_42d8_92bf_b43d2cf7b4c6
 :substance_28899817_2002_42d8_92bf_b43d2cf7b4c6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q104334"@en ;
@@ -961,7 +961,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CarbonicAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_28df7242_f3a7_44e5_bd60_fb16796539c1
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_28df7242_f3a7_44e5_bd60_fb16796539c1
 :substance_28df7242_f3a7_44e5_bd60_fb16796539c1 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_78400dc0_97b0_4d59_8ea6_30bb703f428c ;
@@ -975,7 +975,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Oxygen"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_29611fc5_9fc1_486b_bdbb_33bb8b3ee916
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_29611fc5_9fc1_486b_bdbb_33bb8b3ee916
 :substance_29611fc5_9fc1_486b_bdbb_33bb8b3ee916 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q415520"@en ;
@@ -988,7 +988,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIIIodide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_29b1c15d_2632_40d7_88f7_43575b68b988
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_29b1c15d_2632_40d7_88f7_43575b68b988
 :substance_29b1c15d_2632_40d7_88f7_43575b68b988 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_8e5448fc_1916_4afb_9fd9_2489797f6922 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72461179"@en ;
@@ -1001,7 +1001,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltHydroxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_29dc7a8a_95a6_467c_baa1_25f6a20a5ebe
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_29dc7a8a_95a6_467c_baa1_25f6a20a5ebe
 :substance_29dc7a8a_95a6_467c_baa1_25f6a20a5ebe rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411214"@en ;
@@ -1014,7 +1014,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIISulfate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_29eddf3b_c99a_4624_a520_dc7983da27e0
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_29eddf3b_c99a_4624_a520_dc7983da27e0
 :substance_29eddf3b_c99a_4624_a520_dc7983da27e0 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q416246"@en ;
@@ -1027,7 +1027,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIIBromide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_29ee50d4_27ed_4228_bd26_0010d9310f03
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_29ee50d4_27ed_4228_bd26_0010d9310f03
 :substance_29ee50d4_27ed_4228_bd26_0010d9310f03 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/8179" ;
@@ -1038,13 +1038,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "DiethyleneGlycolDiethylEther"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_29fd347b_6a15_4c98_a982_84cf555b0b86
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_29fd347b_6a15_4c98_a982_84cf555b0b86
 :substance_29fd347b_6a15_4c98_a982_84cf555b0b86 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cc155ed5_c60c_4d9f_bfad_fbf6b7c77e57 ;
                                                 skos:prefLabel "WeakAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_2a540939_3908_4f85_92f9_c46da7d4e9cb
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_2a540939_3908_4f85_92f9_c46da7d4e9cb
 :substance_2a540939_3908_4f85_92f9_c46da7d4e9cb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f24cfd50_5d01_4e02_88b5_44a609cfa432 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407815"@en ;
@@ -1057,7 +1057,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SilverIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_2a87ca10_fc6a_4d61_b48c_d9790a566ee3
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_2a87ca10_fc6a_4d61_b48c_d9790a566ee3
 :substance_2a87ca10_fc6a_4d61_b48c_d9790a566ee3 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_8f1af9c2_9b6d_44f4_8f55_70a4cd5f9dde ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q424955"@en ;
@@ -1070,7 +1070,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_2aace708_cc53_4cc4_bf71_8e09f6521e51
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_2aace708_cc53_4cc4_bf71_8e09f6521e51
 :substance_2aace708_cc53_4cc4_bf71_8e09f6521e51 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_68e4028b_0ec6_46da_8d1c_d00c644e8c82 ;
@@ -1083,7 +1083,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Rubidium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_2ab06c55_4453_4254_8a6e_0447ce1bc76a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_2ab06c55_4453_4254_8a6e_0447ce1bc76a
 :substance_2ab06c55_4453_4254_8a6e_0447ce1bc76a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q18002898"@en ;
@@ -1095,7 +1095,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIISulfite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_2aef236e_eaf8_479d_aaa4_a08392b8a90b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_2aef236e_eaf8_479d_aaa4_a08392b8a90b
 :substance_2aef236e_eaf8_479d_aaa4_a08392b8a90b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q419686"@en ;
@@ -1108,14 +1108,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIIFluoride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_2b7473ba_9156_489a_880f_3a2f746cd104
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_2b7473ba_9156_489a_880f_3a2f746cd104
 :substance_2b7473ba_9156_489a_880f_3a2f746cd104 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 skos:altLabel "Mg(TFOB)2"@en ;
                                                 skos:prefLabel "MagnesiumTrifluoromethanesulfonyloxalatoborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_2b9de1a2_18cc_41ea_81e0_cf576ca56015
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_2b9de1a2_18cc_41ea_81e0_cf576ca56015
 :substance_2b9de1a2_18cc_41ea_81e0_cf576ca56015 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_de038959_9251_48d1_a141_3684f14d957f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q419729"@en ;
@@ -1128,7 +1128,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BerylliumHydroxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_2c0d3403_e3d9_4e5d_93ec_625261f74217
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_2c0d3403_e3d9_4e5d_93ec_625261f74217
 :substance_2c0d3403_e3d9_4e5d_93ec_625261f74217 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_cac14194_2d5f_4fe6_b794_a9319f6d76ee ;
@@ -1141,7 +1141,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Krypton"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_2c83627a_1b7e_43d4_a077_77e1aec35af8
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_2c83627a_1b7e_43d4_a077_77e1aec35af8
 :substance_2c83627a_1b7e_43d4_a077_77e1aec35af8 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q121874"@en ;
@@ -1154,7 +1154,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumIodide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_2c939a73_6363_435a_bbc4_4f6ae02f30d1
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_2c939a73_6363_435a_bbc4_4f6ae02f30d1
 :substance_2c939a73_6363_435a_bbc4_4f6ae02f30d1 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q27118029"@en ;
@@ -1167,7 +1167,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Tetrafluoroborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_2c9a9480_4efd_46fe_929a_5e4506ce429b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_2c9a9480_4efd_46fe_929a_5e4506ce429b
 :substance_2c9a9480_4efd_46fe_929a_5e4506ce429b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q190227"@en ;
@@ -1180,7 +1180,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumCarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_2d7695d2_c033_4949_b8f6_4984dcfdb46a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_2d7695d2_c033_4949_b8f6_4984dcfdb46a
 :substance_2d7695d2_c033_4949_b8f6_4984dcfdb46a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/11552763" ;
@@ -1191,13 +1191,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumTriflate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_2e4767fb_2c1b_43e5_9716_acd3f34b4301
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_2e4767fb_2c1b_43e5_9716_acd3f34b4301
 :substance_2e4767fb_2c1b_43e5_9716_acd3f34b4301 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "PlatinumOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_2e70735d_8769_4416_948b_ab9e856050b7
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_2e70735d_8769_4416_948b_ab9e856050b7
 :substance_2e70735d_8769_4416_948b_ab9e856050b7 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q418767"@en ;
@@ -1210,7 +1210,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumAcetate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_2e758ca0_7f2a_446b_b416_e5bb0ec2dae7
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_2e758ca0_7f2a_446b_b416_e5bb0ec2dae7
 :substance_2e758ca0_7f2a_446b_b416_e5bb0ec2dae7 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q6647971"@en ;
@@ -1223,7 +1223,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumTetrachloroaluminate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_2eaab67b_5117_41a6_b485_2bd53564e44c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_2eaab67b_5117_41a6_b485_2bd53564e44c
 :substance_2eaab67b_5117_41a6_b485_2bd53564e44c rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_78400dc0_97b0_4d59_8ea6_30bb703f428c ;
@@ -1237,7 +1237,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Nitrogen"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_2ee4c506_526d_4483_bca3_b95585f77d00
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_2ee4c506_526d_4483_bca3_b95585f77d00
 :substance_2ee4c506_526d_4483_bca3_b95585f77d00 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_878a0e2f_12ba_484e_8197_75e57139d207 ,
                                                                 :substance_961f7671_8708_4ce3_9c7d_79444adba9c0 ;
@@ -1251,7 +1251,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IsopropylAlcohol"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_2f1bbf42_2021_453e_baf0_937607b4919e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_2f1bbf42_2021_453e_baf0_937607b4919e
 :substance_2f1bbf42_2021_453e_baf0_937607b4919e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q180713"@en ;
@@ -1264,13 +1264,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIIAcetate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_2fc3e95b_6f48_47ea_a366_bcc26336239a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_2fc3e95b_6f48_47ea_a366_bcc26336239a
 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ;
                                                 skos:prefLabel "TransitionMetalElementalSubstance"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_30078875_6d7b_4c2b_8cae_1c73e6031163
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_30078875_6d7b_4c2b_8cae_1c73e6031163
 :substance_30078875_6d7b_4c2b_8cae_1c73e6031163 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_878a0e2f_12ba_484e_8197_75e57139d207 ,
                                                                 :substance_961f7671_8708_4ce3_9c7d_79444adba9c0 ;
@@ -1284,7 +1284,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NButanol"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_3016a276_0f17_4576_b8fd_200c07d71bfc
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_3016a276_0f17_4576_b8fd_200c07d71bfc
 :substance_3016a276_0f17_4576_b8fd_200c07d71bfc rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q188543"@en ;
@@ -1297,7 +1297,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumChloride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_3061643c_9dea_4e98_bc1f_6e1a28567c1d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_3061643c_9dea_4e98_bc1f_6e1a28567c1d
 :substance_3061643c_9dea_4e98_bc1f_6e1a28567c1d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421071"@en ;
@@ -1310,7 +1310,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIIChloride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_30960f1f_5af5_4700_8df8_428c994b5cb6
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_30960f1f_5af5_4700_8df8_428c994b5cb6
 :substance_30960f1f_5af5_4700_8df8_428c994b5cb6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q159096"@en ;
@@ -1323,7 +1323,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumIodide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_31d0d139_7b45_4d1e_8603_92cc12da2fad
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_31d0d139_7b45_4d1e_8603_92cc12da2fad
 :substance_31d0d139_7b45_4d1e_8603_92cc12da2fad rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2802973"@en ;
@@ -1336,7 +1336,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "VinyleneCarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_3210b87b_988f_49f5_99a8_0a20cd42db57
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_3210b87b_988f_49f5_99a8_0a20cd42db57
 :substance_3210b87b_988f_49f5_99a8_0a20cd42db57 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -1349,7 +1349,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Hexamethylphosphoramide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_323a2e39_d7d5_4802_884a_9aa41a280986
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_323a2e39_d7d5_4802_884a_9aa41a280986
 :substance_323a2e39_d7d5_4802_884a_9aa41a280986 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_8e5448fc_1916_4afb_9fd9_2489797f6922 ;
@@ -1361,7 +1361,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IronIIIHydroxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_3286d184_258d_4f80_965b_b9277d57f1b0
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_3286d184_258d_4f80_965b_b9277d57f1b0
 :substance_3286d184_258d_4f80_965b_b9277d57f1b0 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407189"@en ;
@@ -1373,7 +1373,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Perchlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_3297942c_1564_44de_a966_c04fa5da0a4e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_3297942c_1564_44de_a966_c04fa5da0a4e
 :substance_3297942c_1564_44de_a966_c04fa5da0a4e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q27292979"@en ;
@@ -1385,7 +1385,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincTetrafluoroborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_334b7617_34d5_4cb4_9e03_cde9ff19183d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_334b7617_34d5_4cb4_9e03_cde9ff19183d
 :substance_334b7617_34d5_4cb4_9e03_cde9ff19183d rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_b978912b_19ef_4d46_8c91_2e3578b12670 ;
@@ -1398,14 +1398,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Bismuth"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_3370cbd2_3fb0_47ba_9a20_50124ae6b4cb
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_3370cbd2_3fb0_47ba_9a20_50124ae6b4cb
 :substance_3370cbd2_3fb0_47ba_9a20_50124ae6b4cb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 skos:altLabel "LiTFOB"@en ;
                                                 skos:prefLabel "LithiumTrifluoromethanesulfonyloxalatoborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_3421af1a_a9fc_4079_a1a5_37d828f0c94b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_3421af1a_a9fc_4079_a1a5_37d828f0c94b
 :substance_3421af1a_a9fc_4079_a1a5_37d828f0c94b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72494142"@en ;
@@ -1417,7 +1417,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIITriflate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_350eaefc_75e1_49d8_b161_01a634607857
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_350eaefc_75e1_49d8_b161_01a634607857
 :substance_350eaefc_75e1_49d8_b161_01a634607857 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_29fd347b_6a15_4c98_a982_84cf555b0b86 ;
@@ -1431,7 +1431,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PhosphoricAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_352ee172_3801_4ccd_89b9_4b80e80ee1e5
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_352ee172_3801_4ccd_89b9_4b80e80ee1e5
 :substance_352ee172_3801_4ccd_89b9_4b80e80ee1e5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q414440"@en ;
@@ -1444,13 +1444,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumSulfate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_3540fb20_f719_42eb_ad0c_112ffedb7c6d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_3540fb20_f719_42eb_ad0c_112ffedb7c6d
 :substance_3540fb20_f719_42eb_ad0c_112ffedb7c6d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "CadmiumOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_35dec16f_58dc_41be_9878_a3c29fd5cdd2
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_35dec16f_58dc_41be_9878_a3c29fd5cdd2
 :substance_35dec16f_58dc_41be_9878_a3c29fd5cdd2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q417109"@en ;
@@ -1463,7 +1463,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumSulfite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_3604e3b6_2e54_41b2_b204_f52a427b990a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_3604e3b6_2e54_41b2_b204_f52a427b990a
 :substance_3604e3b6_2e54_41b2_b204_f52a427b990a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407796"@en ;
@@ -1475,7 +1475,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PentanoicAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_361464d9_c796_413f_b261_0a321d68f04a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_361464d9_c796_413f_b261_0a321d68f04a
 :substance_361464d9_c796_413f_b261_0a321d68f04a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411859"@en ;
@@ -1488,7 +1488,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumChloride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_371fbcaa_d782_4f4c_86e3_58e1a58d3bea
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_371fbcaa_d782_4f4c_86e3_58e1a58d3bea
 :substance_371fbcaa_d782_4f4c_86e3_58e1a58d3bea rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a9218f8f_2e80_497e_b968_b4947cf21802 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q36200"@en ;
@@ -1501,7 +1501,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZirconiumIVOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_37c4342f_3c3f_47d3_97f0_761c8c877933
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_37c4342f_3c3f_47d3_97f0_761c8c877933
 :substance_37c4342f_3c3f_47d3_97f0_761c8c877933 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a9a6507f_9c61_44d3_bd86_f1ebf763e150 ;
@@ -1515,7 +1515,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Germanium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_38178633_83fb_42ea_81a2_cd23e9db9b04
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_38178633_83fb_42ea_81a2_cd23e9db9b04
 :substance_38178633_83fb_42ea_81a2_cd23e9db9b04 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_cac14194_2d5f_4fe6_b794_a9319f6d76ee ;
@@ -1528,7 +1528,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Argon"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_383f6ea4_344d_4f3f_ae04_4c5005e9c8fd
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_383f6ea4_344d_4f3f_ae04_4c5005e9c8fd
 :substance_383f6ea4_344d_4f3f_ae04_4c5005e9c8fd rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_52da9471_9979_44b0_a415_63c72110fd43 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q419170"@en ;
@@ -1538,7 +1538,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IronIIIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_385410f6_0c03_4942_b35f_52a664b5622c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_385410f6_0c03_4942_b35f_52a664b5622c
 :substance_385410f6_0c03_4942_b35f_52a664b5622c rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421458"@en ;
@@ -1552,14 +1552,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TetraethylOrthosilicate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_3896eebe_80a4_441a_bd73_52be793482a6
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_3896eebe_80a4_441a_bd73_52be793482a6
 :substance_3896eebe_80a4_441a_bd73_52be793482a6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 skos:altLabel "Sr(PF6)2"@en ;
                                                 skos:prefLabel "StrontiumHexafluorophosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_3899a9c9_9b34_443e_8ce6_0257589bb38a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_3899a9c9_9b34_443e_8ce6_0257589bb38a
 :substance_3899a9c9_9b34_443e_8ce6_0257589bb38a rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1079788" ;
@@ -1575,7 +1575,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
  ] .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_3ac62305_acd6_4312_9e31_4f824bd2530d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_3ac62305_acd6_4312_9e31_4f824bd2530d
 :substance_3ac62305_acd6_4312_9e31_4f824bd2530d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q121086245"@en ;
@@ -1584,7 +1584,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumNickelManganeseCobaltOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_3b02df00_df48_4e41_aea1_d291681dcf0e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_3b02df00_df48_4e41_aea1_d291681dcf0e
 :substance_3b02df00_df48_4e41_aea1_d291681dcf0e rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_b978912b_19ef_4d46_8c91_2e3578b12670 ;
@@ -1597,7 +1597,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Polonium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_3c8fb431_7d9d_4a89_a494_708df34f44d3
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_3c8fb431_7d9d_4a89_a494_708df34f44d3
 :substance_3c8fb431_7d9d_4a89_a494_708df34f44d3 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q413421"@en ;
@@ -1610,7 +1610,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Dimethylsulfate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_3d3ca8c8_4ea0_43b8_b496_aca78a0d1584
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_3d3ca8c8_4ea0_43b8_b496_aca78a0d1584
 :substance_3d3ca8c8_4ea0_43b8_b496_aca78a0d1584 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/16700902" ;
@@ -1621,7 +1621,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIIPhosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_3d6c473f_fdfb_4f8a_922e_215d18691e21
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_3d6c473f_fdfb_4f8a_922e_215d18691e21
 :substance_3d6c473f_fdfb_4f8a_922e_215d18691e21 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/83717" ;
@@ -1632,7 +1632,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIIIodide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_3dfd47ff_ed4b_4e83_85a0_02917b79fef9
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_3dfd47ff_ed4b_4e83_85a0_02917b79fef9
 :substance_3dfd47ff_ed4b_4e83_85a0_02917b79fef9 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_8e5448fc_1916_4afb_9fd9_2489797f6922 ;
@@ -1646,7 +1646,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Ammonia"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_3eaad9be_eae9_4735_b03a_1b07f9f79805
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_3eaad9be_eae9_4735_b03a_1b07f9f79805
 :substance_3eaad9be_eae9_4735_b03a_1b07f9f79805 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411207"@en ;
@@ -1659,7 +1659,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIIodide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_3f5d5e9c_adb6_4fbb_88a5_1d5472e2c99f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_3f5d5e9c_adb6_4fbb_88a5_1d5472e2c99f
 :substance_3f5d5e9c_adb6_4fbb_88a5_1d5472e2c99f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4493207"@en ;
@@ -1672,7 +1672,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIIFluoride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_3fd0b901_88fa_47e2_9d99_7db13cd02c9f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_3fd0b901_88fa_47e2_9d99_7db13cd02c9f
 :substance_3fd0b901_88fa_47e2_9d99_7db13cd02c9f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2754907"@en ;
@@ -1685,7 +1685,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumTetrafluoroborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_40bdf780_394e_49e8_9a46_c88320c9d734
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_40bdf780_394e_49e8_9a46_c88320c9d734
 :substance_40bdf780_394e_49e8_9a46_c88320c9d734 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q899410"@en ;
@@ -1698,7 +1698,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumSulfite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4112b3b8_69fa_4f20_9f99_f572f57ab66f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4112b3b8_69fa_4f20_9f99_f572f57ab66f
 :substance_4112b3b8_69fa_4f20_9f99_f572f57ab66f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q424906"@en ;
@@ -1710,7 +1710,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "GlycericAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4126ee09_b9c6_4694_bf33_0d8970e05f72
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4126ee09_b9c6_4694_bf33_0d8970e05f72
 :substance_4126ee09_b9c6_4694_bf33_0d8970e05f72 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc9ba950_96c1_4ac2_a0e2_1c4f7f001b1d ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407879"@en ;
@@ -1723,7 +1723,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_41379755_2818_4dea_b3d3_15ac755fb751
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_41379755_2818_4dea_b3d3_15ac755fb751
 :substance_41379755_2818_4dea_b3d3_15ac755fb751 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q414860"@en ;
@@ -1736,7 +1736,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIINitrate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_413d32e9_2ec2_474a_9ddb_48277920ba21
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_413d32e9_2ec2_474a_9ddb_48277920ba21
 :substance_413d32e9_2ec2_474a_9ddb_48277920ba21 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q27266022"@en ;
@@ -1749,13 +1749,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincPerchlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4154e6b6_8e3c_4173_91aa_e8ba403bde85
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4154e6b6_8e3c_4173_91aa_e8ba403bde85
 :substance_4154e6b6_8e3c_4173_91aa_e8ba403bde85 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_015116fe_94ca_4be5_9d14_9d9457a47a72 ;
                                                 skos:prefLabel "IronSalt"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_41bcd359_dc00_45f4_8746_d40c91e64f94
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_41bcd359_dc00_45f4_8746_d40c91e64f94
 :substance_41bcd359_dc00_45f4_8746_d40c91e64f94 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q423852"@en ;
@@ -1768,14 +1768,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumPhosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_41cd4dfd_2288_48b2_a1e3_d13821c21a1e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_41cd4dfd_2288_48b2_a1e3_d13821c21a1e
 :substance_41cd4dfd_2288_48b2_a1e3_d13821c21a1e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 skos:altLabel "Sr(FSI)2"@en ;
                                                 skos:prefLabel "StrontiumBisfluorosulfonylimide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4216bdc4_ef30_43e6_bd44_47f78761939e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4216bdc4_ef30_43e6_bd44_47f78761939e
 :substance_4216bdc4_ef30_43e6_bd44_47f78761939e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q18211720"@en ;
@@ -1788,7 +1788,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumNitrite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4295c63e_3024_4e69_8da5_102861bebac1
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4295c63e_3024_4e69_8da5_102861bebac1
 :substance_4295c63e_3024_4e69_8da5_102861bebac1 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dc68514f_b592_4e1b_a00f_fbb29f2fafbd ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q412967"@en ;
@@ -1800,7 +1800,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Nafion"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4310c690_9810_4a95_8d62_7e78e0b84437
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4310c690_9810_4a95_8d62_7e78e0b84437
 :substance_4310c690_9810_4a95_8d62_7e78e0b84437 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421198"@en ;
@@ -1813,7 +1813,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIIAcetate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_43aef3e7_12aa_44b2_9d0f_973e634bfbe0
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_43aef3e7_12aa_44b2_9d0f_973e634bfbe0
 :substance_43aef3e7_12aa_44b2_9d0f_973e634bfbe0 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_78400dc0_97b0_4d59_8ea6_30bb703f428c ;
@@ -1827,14 +1827,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Chlorine"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_43ec3168_0f1a_44aa_99ad_716fcc48bbcb
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_43ec3168_0f1a_44aa_99ad_716fcc48bbcb
 :substance_43ec3168_0f1a_44aa_99ad_716fcc48bbcb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 skos:altLabel "Mg(FSI)2"@en ;
                                                 skos:prefLabel "MagnesiumBisfluorosulfonylimide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_44a9a4e3_488e_4687_aca7_b045e12147f7
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_44a9a4e3_488e_4687_aca7_b045e12147f7
 :substance_44a9a4e3_488e_4687_aca7_b045e12147f7 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_155e894b_66de_4cda_9dbe_adbeca7d8102 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204980"@en ;
@@ -1847,7 +1847,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TinIIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4525c1ee_1d0c_4a17_9fa8_24c19c690db6
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4525c1ee_1d0c_4a17_9fa8_24c19c690db6
 :substance_4525c1ee_1d0c_4a17_9fa8_24c19c690db6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q11129394"@en ;
@@ -1860,7 +1860,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumChlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_465f2569_2bb8_4360_a2cb_480017390074
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_465f2569_2bb8_4360_a2cb_480017390074
 :substance_465f2569_2bb8_4360_a2cb_480017390074 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q425274"@en ;
@@ -1873,7 +1873,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIINitrate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_469e5dc9_7b3e_4e72_8fd5_fe2e8386862d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_469e5dc9_7b3e_4e72_8fd5_fe2e8386862d
 :substance_469e5dc9_7b3e_4e72_8fd5_fe2e8386862d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/10130077" ;
@@ -1884,7 +1884,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIINitrite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_46e9f253_40cb_4b48_b8d0_0b976ea4e156
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_46e9f253_40cb_4b48_b8d0_0b976ea4e156
 :substance_46e9f253_40cb_4b48_b8d0_0b976ea4e156 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -1898,7 +1898,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PropyleneCarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_46eb3e23_0d77_4e1e_9c3c_48a47f8d022c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_46eb3e23_0d77_4e1e_9c3c_48a47f8d022c
 :substance_46eb3e23_0d77_4e1e_9c3c_48a47f8d022c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q426354"@en ;
@@ -1910,13 +1910,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumPhosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4744a12c_ca28_46b4_9e59_43c1cc15b536
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4744a12c_ca28_46b4_9e59_43c1cc15b536
 :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_6c490298_2ce8_41e1_ac37_4b44faff2d44 ;
                                                 skos:prefLabel "LithiumSaltCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_47766d88_0ded_4f5c_87f9_f810fe5ce02b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_47766d88_0ded_4f5c_87f9_f810fe5ce02b
 :substance_47766d88_0ded_4f5c_87f9_f810fe5ce02b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q8010655"@en ;
@@ -1929,7 +1929,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumTetrachloroaluminate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4780139a_615a_4a28_a7be_bbbb28f3ec68
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4780139a_615a_4a28_a7be_bbbb28f3ec68
 :substance_4780139a_615a_4a28_a7be_bbbb28f3ec68 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q177836"@en ;
@@ -1942,7 +1942,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumNitrate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4796594d_8de9_482d_9644_7ee776941dc2
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4796594d_8de9_482d_9644_7ee776941dc2
 :substance_4796594d_8de9_482d_9644_7ee776941dc2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a639df56_1fb2_47f3_8069_c929b5a84b86 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q425350"@en ;
@@ -1955,7 +1955,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "VanadiumIIIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_47a21fb6_2158_4f41_8f74_5b873d5eae53
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_47a21fb6_2158_4f41_8f74_5b873d5eae53
 :substance_47a21fb6_2158_4f41_8f74_5b873d5eae53 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q899422"@en ;
@@ -1968,7 +1968,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIIAcetate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_480a4c29_fa1b_4e14_b5e0_a0b82d73df57
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_480a4c29_fa1b_4e14_b5e0_a0b82d73df57
 :substance_480a4c29_fa1b_4e14_b5e0_a0b82d73df57 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72487598"@en ;
@@ -1980,7 +1980,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumDifluorooxalatoborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_48108f36_d856_46d4_b293_e174aeff9970
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_48108f36_d856_46d4_b293_e174aeff9970
 :substance_48108f36_d856_46d4_b293_e174aeff9970 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/substance/482775751" ;
@@ -1988,7 +1988,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIITriflate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_48831514_d92f_4c67_8065_98df6f4d11cb
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_48831514_d92f_4c67_8065_98df6f4d11cb
 :substance_48831514_d92f_4c67_8065_98df6f4d11cb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q211737"@en ;
@@ -2001,7 +2001,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumSulfate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4a00b074_17b5_417c_996b_d0ac47041030
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4a00b074_17b5_417c_996b_d0ac47041030
 :substance_4a00b074_17b5_417c_996b_d0ac47041030 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q194322"@en ;
@@ -2013,7 +2013,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TartaricAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4a72632d_2168_4f66_8cd7_e764ea7909d6
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4a72632d_2168_4f66_8cd7_e764ea7909d6
 :substance_4a72632d_2168_4f66_8cd7_e764ea7909d6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421250"@en ;
@@ -2026,7 +2026,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIIIodide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4a839093_754f_4ba2_920b_0681697f32b3
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4a839093_754f_4ba2_920b_0681697f32b3
 :substance_4a839093_754f_4ba2_920b_0681697f32b3 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72502023"@en ;
@@ -2038,13 +2038,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumTriflate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4ad18bbe_6478_4009_8f80_b669a6ae3f7a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4ad18bbe_6478_4009_8f80_b669a6ae3f7a
 :substance_4ad18bbe_6478_4009_8f80_b669a6ae3f7a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "IridiumOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4b3e8f9e_9857_4bc3_8e17_aa75757d9860
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4b3e8f9e_9857_4bc3_8e17_aa75757d9860
 :substance_4b3e8f9e_9857_4bc3_8e17_aa75757d9860 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q420146"@en ;
@@ -2057,7 +2057,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumNitrate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4c01eadc_81a0_4ad7_a72f_4d5f72f60f04
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4c01eadc_81a0_4ad7_a72f_4d5f72f60f04
 :substance_4c01eadc_81a0_4ad7_a72f_4d5f72f60f04 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/23677815" ;
@@ -2068,7 +2068,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumBisoxalatoborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4c6265b5_d9e4_4493_b1e8_ae35f463ceeb
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4c6265b5_d9e4_4493_b1e8_ae35f463ceeb
 :substance_4c6265b5_d9e4_4493_b1e8_ae35f463ceeb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q20107470"@en ;
@@ -2080,7 +2080,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumPerchlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4c62d334_a124_40b3_9fd1_fe713d01a6af
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4c62d334_a124_40b3_9fd1_fe713d01a6af
 :substance_4c62d334_a124_40b3_9fd1_fe713d01a6af rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q415891"@en ;
@@ -2093,13 +2093,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumCobaltOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4ca80d73_ea14_4a81_9df1_8a16ecbfd041
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4ca80d73_ea14_4a81_9df1_8a16ecbfd041
 :substance_4ca80d73_ea14_4a81_9df1_8a16ecbfd041 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "RutheniumOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4cb44b89_42ca_481e_b883_ab9cf6621862
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4cb44b89_42ca_481e_b883_ab9cf6621862
 :substance_4cb44b89_42ca_481e_b883_ab9cf6621862 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2314"@en ;
@@ -2112,14 +2112,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumChloride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4d6845ce_47c8_4c7d_b275_1d4494a0799b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4d6845ce_47c8_4c7d_b275_1d4494a0799b
 :substance_4d6845ce_47c8_4c7d_b275_1d4494a0799b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 skos:altLabel "Ba(TFOB)2"@en ;
                                                 skos:prefLabel "BariumTrifluoromethanesulfonyloxalatoborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4de6c4d5_0d8d_418c_b3f0_c780f000cd55
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4de6c4d5_0d8d_418c_b3f0_c780f000cd55
 :substance_4de6c4d5_0d8d_418c_b3f0_c780f000cd55 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409501"@en ;
@@ -2132,7 +2132,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumPhosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4e27d4ae_cb93_475a_8a97_121fc8e0248e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4e27d4ae_cb93_475a_8a97_121fc8e0248e
 :substance_4e27d4ae_cb93_475a_8a97_121fc8e0248e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q339940"@en ;
@@ -2145,7 +2145,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumAcetate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4e2e3adb_47cc_44d8_a3c3_28257dffcb28
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4e2e3adb_47cc_44d8_a3c3_28257dffcb28
 :substance_4e2e3adb_47cc_44d8_a3c3_28257dffcb28 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q415543"@en ;
@@ -2158,7 +2158,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumSulfite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4e5582a6_caec_4917_acad_6f472cd7d831
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4e5582a6_caec_4917_acad_6f472cd7d831
 :substance_4e5582a6_caec_4917_acad_6f472cd7d831 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_78400dc0_97b0_4d59_8ea6_30bb703f428c ;
@@ -2172,7 +2172,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Carbon"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4ebbe70b_3bba_4b8c_90fc_684017abe192
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4ebbe70b_3bba_4b8c_90fc_684017abe192
 :substance_4ebbe70b_3bba_4b8c_90fc_684017abe192 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q417847"@en ;
@@ -2185,7 +2185,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SuccinicAnhydride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4ebc1929_2acd_4afb_8a13_6b2f70e2956c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4ebc1929_2acd_4afb_8a13_6b2f70e2956c
 :substance_4ebc1929_2acd_4afb_8a13_6b2f70e2956c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q410107"@en ;
@@ -2199,7 +2199,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Cumene"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4ec21ff2_f0f3_470f_8855_05ba6a074ecf
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4ec21ff2_f0f3_470f_8855_05ba6a074ecf
 :substance_4ec21ff2_f0f3_470f_8855_05ba6a074ecf rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q408491"@en ;
@@ -2212,7 +2212,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumPerchlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_4ed2fb2e_2e73_43c1_bc98_4d0ee34f859e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_4ed2fb2e_2e73_43c1_bc98_4d0ee34f859e
 :substance_4ed2fb2e_2e73_43c1_bc98_4d0ee34f859e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/20073715" ;
@@ -2223,7 +2223,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIIHexafluorophosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_505b0b88_e622_43e7_bf5e_d04c0b540ccb
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_505b0b88_e622_43e7_bf5e_d04c0b540ccb
 :substance_505b0b88_e622_43e7_bf5e_d04c0b540ccb rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_78400dc0_97b0_4d59_8ea6_30bb703f428c ;
@@ -2237,7 +2237,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Fluorine"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_5088ad54_b37d_4ee1_a086_d6c17e644f9a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_5088ad54_b37d_4ee1_a086_d6c17e644f9a
 :substance_5088ad54_b37d_4ee1_a086_d6c17e644f9a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b8c65e71_05de_4f07_acd8_a16938b550fd ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411221"@en ;
@@ -2250,7 +2250,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_508e6e27_16a6_40f4_930c_d6c793721181
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_508e6e27_16a6_40f4_930c_d6c793721181
 :substance_508e6e27_16a6_40f4_930c_d6c793721181 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q413374"@en ;
@@ -2263,7 +2263,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumFluoride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_513a92b2_26b5_420d_8cf9_922869bbec61
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_513a92b2_26b5_420d_8cf9_922869bbec61
 :substance_513a92b2_26b5_420d_8cf9_922869bbec61 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -2276,7 +2276,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Hafnium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_51e414c6_e619_446c_898a_dac0f4855584
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_51e414c6_e619_446c_898a_dac0f4855584
 :substance_51e414c6_e619_446c_898a_dac0f4855584 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q59714"@en ;
@@ -2289,7 +2289,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincPhosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_5263c4d3_8759_48a1_b35e_5abf7a1f0454
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_5263c4d3_8759_48a1_b35e_5abf7a1f0454
 :substance_5263c4d3_8759_48a1_b35e_5abf7a1f0454 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411752"@en ;
@@ -2302,7 +2302,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumFluoride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_527fbfa6_7a48_4f6e_8442_38f2590a51bb
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_527fbfa6_7a48_4f6e_8442_38f2590a51bb
 :substance_527fbfa6_7a48_4f6e_8442_38f2590a51bb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409739"@en ;
@@ -2315,7 +2315,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumBromide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_52c1076c_9349_44f7_8067_4de36bd49e10
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_52c1076c_9349_44f7_8067_4de36bd49e10
 :substance_52c1076c_9349_44f7_8067_4de36bd49e10 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q408925"@en ;
@@ -2327,13 +2327,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "HydrazoicAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_52da9471_9979_44b0_a415_63c72110fd43
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_52da9471_9979_44b0_a415_63c72110fd43
 :substance_52da9471_9979_44b0_a415_63c72110fd43 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "IronOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_53682797_c388_4407_9410_1fa6a41fa1da
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_53682797_c388_4407_9410_1fa6a41fa1da
 :substance_53682797_c388_4407_9410_1fa6a41fa1da rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q417992"@en ;
@@ -2346,7 +2346,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumIodide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_53c372d6_b1fa_4e53_93b3_0904c0580d28
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_53c372d6_b1fa_4e53_93b3_0904c0580d28
 :substance_53c372d6_b1fa_4e53_93b3_0904c0580d28 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421465"@en ;
@@ -2359,7 +2359,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumIodide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_5414a9d0_6c2e_4d21_bfad_9a19fc8f62f9
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_5414a9d0_6c2e_4d21_bfad_9a19fc8f62f9
 :substance_5414a9d0_6c2e_4d21_bfad_9a19fc8f62f9 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2336041"@en ;
@@ -2372,7 +2372,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumSulfite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_54f744b3_1d02_4571_a303_a2a7dd8f0446
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_54f744b3_1d02_4571_a303_a2a7dd8f0446
 :substance_54f744b3_1d02_4571_a303_a2a7dd8f0446 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q413982"@en ;
@@ -2385,7 +2385,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumBromide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_55080032_1536_4cf7_a4a6_7784422720f5
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_55080032_1536_4cf7_a4a6_7784422720f5
 :substance_55080032_1536_4cf7_a4a6_7784422720f5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q6135415"@en ;
@@ -2397,21 +2397,21 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIISulfite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_55b09b6b_c8cd_410c_8971_b2bd86e0c905
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_55b09b6b_c8cd_410c_8971_b2bd86e0c905
 :substance_55b09b6b_c8cd_410c_8971_b2bd86e0c905 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 skos:altLabel "Ca(DFOB)2"@en ;
                                                 skos:prefLabel "CalciumDifluorooxalatoborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_55d2a257_feb3_4af1_bf8d_4b53bb73610c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_55d2a257_feb3_4af1_bf8d_4b53bb73610c
 :substance_55d2a257_feb3_4af1_bf8d_4b53bb73610c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 skos:altLabel "Ba(BOP)2"@en ;
                                                 skos:prefLabel "BariumBisoxalatophosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_55f13456_b4b6_4cf9_998c_8c439b249b3f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_55f13456_b4b6_4cf9_998c_8c439b249b3f
 :substance_55f13456_b4b6_4cf9_998c_8c439b249b3f rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -2424,7 +2424,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Zirconium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_564edbfa_af96_41c5_8fd5_7f22b1ca658d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_564edbfa_af96_41c5_8fd5_7f22b1ca658d
 :substance_564edbfa_af96_41c5_8fd5_7f22b1ca658d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q27274769"@en ;
@@ -2437,7 +2437,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIIAcetate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_56639835_9f0b_493f_a38c_268185ef4947
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_56639835_9f0b_493f_a38c_268185ef4947
 :substance_56639835_9f0b_493f_a38c_268185ef4947 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4ca80d73_ea14_4a81_9df1_8a16ecbfd041 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q416759"@en ;
@@ -2450,7 +2450,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "RutheniumVIIIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_56a8e7ef_29da_46d2_92e4_81c38ec39b4b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_56a8e7ef_29da_46d2_92e4_81c38ec39b4b
 :substance_56a8e7ef_29da_46d2_92e4_81c38ec39b4b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409251"@en ;
@@ -2463,7 +2463,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumAcetate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_56c59d5b_ace2_4b5a_9144_fc97f93f9a93
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_56c59d5b_ace2_4b5a_9144_fc97f93f9a93
 :substance_56c59d5b_ace2_4b5a_9144_fc97f93f9a93 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_001ca83b_5372_4d77_a836_4d48074b7e63 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2985790"@en ;
@@ -2476,7 +2476,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TitaniumIIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_56cdced5_3773_4839_9269_df2d13ea9224
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_56cdced5_3773_4839_9269_df2d13ea9224
 :substance_56cdced5_3773_4839_9269_df2d13ea9224 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0dcf209c_6455_4305_9714_fec548742c6a ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421063"@en ;
@@ -2489,7 +2489,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PalladiumOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_57015be9_f515_4e00_b914_e8130d596bcb
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_57015be9_f515_4e00_b914_e8130d596bcb
 :substance_57015be9_f515_4e00_b914_e8130d596bcb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/102195115" ;
@@ -2499,7 +2499,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TDI"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_57339d90_0553_4a96_8da9_ff6c3684e226
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_57339d90_0553_4a96_8da9_ff6c3684e226
 :substance_57339d90_0553_4a96_8da9_ff6c3684e226 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421145"@en ;
@@ -2513,7 +2513,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "EthyleneCarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_573a02c5_da67_438f_9056_f66caa1febaf
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_573a02c5_da67_438f_9056_f66caa1febaf
 :substance_573a02c5_da67_438f_9056_f66caa1febaf rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Nickel(II)_chloride"@en ;
@@ -2526,7 +2526,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIIChloride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_573ba7a1_f6a6_427d_99de_8e80fe406a67
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_573ba7a1_f6a6_427d_99de_8e80fe406a67
 :substance_573ba7a1_f6a6_427d_99de_8e80fe406a67 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q413629"@en ;
@@ -2539,13 +2539,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumCarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_584bfc73_2715_417f_973c_552ae58529f5
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_584bfc73_2715_417f_973c_552ae58529f5
 :substance_584bfc73_2715_417f_973c_552ae58529f5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_6c490298_2ce8_41e1_ac37_4b44faff2d44 ;
                                                 skos:prefLabel "SodiumSaltCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_59168cd9_e3af_4345_96e9_88a80afd3d16
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_59168cd9_e3af_4345_96e9_88a80afd3d16
 :substance_59168cd9_e3af_4345_96e9_88a80afd3d16 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a4a5b239_d88e_4e03_a763_0bf2a3dd0f47 ;
@@ -2559,7 +2559,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Magnesium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_597d0bee_eb9b_4264_9888_2c1400690a5d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_597d0bee_eb9b_4264_9888_2c1400690a5d
 :substance_597d0bee_eb9b_4264_9888_2c1400690a5d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2937970"@en ;
@@ -2572,7 +2572,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumHexafluorophosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_59c65403_b7f9_4852_a37a_e6295c7b026c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_59c65403_b7f9_4852_a37a_e6295c7b026c
 :substance_59c65403_b7f9_4852_a37a_e6295c7b026c rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -2586,7 +2586,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NMethyl2Pyrrolidone"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_59db0926_27f3_444d_b3b7_126e9ea0b8e3
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_59db0926_27f3_444d_b3b7_126e9ea0b8e3
 :substance_59db0926_27f3_444d_b3b7_126e9ea0b8e3 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204952"@en ;
@@ -2599,19 +2599,19 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincSulfide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_5a4d05f1_dd15_465b_8b44_704238e20813
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_5a4d05f1_dd15_465b_8b44_704238e20813
 :substance_5a4d05f1_dd15_465b_8b44_704238e20813 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "ManganeseOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4
 :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f07ae87e_b56e_4835_8a28_04c6c7dfbaa2 ;
                                                 skos:prefLabel "Anion"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_5a88a655_4e82_4b86_8636_50c70609536f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_5a88a655_4e82_4b86_8636_50c70609536f
 :substance_5a88a655_4e82_4b86_8636_50c70609536f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411848"@en ;
@@ -2624,7 +2624,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIIChloride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_5b24c742_1149_4533_8d48_41473396d06d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_5b24c742_1149_4533_8d48_41473396d06d
 :substance_5b24c742_1149_4533_8d48_41473396d06d rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_de038959_9251_48d1_a141_3684f14d957f ;
@@ -2638,7 +2638,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Hydroxylamine "@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_5bc7a64d_ec8d_4350_9e03_67fac740d00a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_5bc7a64d_ec8d_4350_9e03_67fac740d00a
 :substance_5bc7a64d_ec8d_4350_9e03_67fac740d00a rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q3562143"@en ;
@@ -2651,7 +2651,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TrisPentafluorophenylBorane"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_5ca70573_eeed_4fed_af97_32560b532ccd
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_5ca70573_eeed_4fed_af97_32560b532ccd
 :substance_5ca70573_eeed_4fed_af97_32560b532ccd rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_001ca83b_5372_4d77_a836_4d48074b7e63 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2626625"@en ;
@@ -2664,7 +2664,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TitaniumIIIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_5ce53b37_1248_43b0_8862_ef4bff996dcf
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_5ce53b37_1248_43b0_8862_ef4bff996dcf
 :substance_5ce53b37_1248_43b0_8862_ef4bff996dcf rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -2677,7 +2677,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Niobium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_5cee19d2_f916_4264_a8ed_efed13a808d2
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_5cee19d2_f916_4264_a8ed_efed13a808d2
 :substance_5cee19d2_f916_4264_a8ed_efed13a808d2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_6c0cc397_d8c4_4473_a09f_1e5de568e0dd ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q105038172"@en ;
@@ -2685,7 +2685,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "HardCarbon"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_5d128b6c_3e70_470c_b24e_0b953ef76486
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_5d128b6c_3e70_470c_b24e_0b953ef76486
 :substance_5d128b6c_3e70_470c_b24e_0b953ef76486 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/79119" ;
@@ -2696,7 +2696,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ThreeMeSulfolane"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_5e44fe20_093d_4848_84ef_a20d69c17f3f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_5e44fe20_093d_4848_84ef_a20d69c17f3f
 :substance_5e44fe20_093d_4848_84ef_a20d69c17f3f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q339975"@en ;
@@ -2709,7 +2709,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumNitrite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_5fbecfe6_4d2f_467d_a301_f4698b0ea7dd
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_5fbecfe6_4d2f_467d_a301_f4698b0ea7dd
 :substance_5fbecfe6_4d2f_467d_a301_f4698b0ea7dd rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -2722,7 +2722,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Molybdenum"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_5fde02de_e08f_4854_9fe0_1e967bb3f60d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_5fde02de_e08f_4854_9fe0_1e967bb3f60d
 :substance_5fde02de_e08f_4854_9fe0_1e967bb3f60d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Cobalt(II)_carbonate"@en ;
@@ -2735,7 +2735,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIICarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_603164db_76c9_407b_be5c_8fa9b73f2dcc
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_603164db_76c9_407b_be5c_8fa9b73f2dcc
 :substance_603164db_76c9_407b_be5c_8fa9b73f2dcc rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q417970"@en ;
@@ -2748,7 +2748,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumPerchlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_60441902_f7f6_4747_99c7_e15eb8c73706
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_60441902_f7f6_4747_99c7_e15eb8c73706
 :substance_60441902_f7f6_4747_99c7_e15eb8c73706 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q27121260"@en ;
@@ -2760,7 +2760,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Trifluoromethanesulfonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_60acd62d_2834_46b0_aca8_a4c497763d77
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_60acd62d_2834_46b0_aca8_a4c497763d77
 :substance_60acd62d_2834_46b0_aca8_a4c497763d77 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_cac14194_2d5f_4fe6_b794_a9319f6d76ee ;
@@ -2773,7 +2773,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Xenon"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_61250895_082a_46e8_8ce5_b8f6b3710866
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_61250895_082a_46e8_8ce5_b8f6b3710866
 :substance_61250895_082a_46e8_8ce5_b8f6b3710866 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q18234771"@en ;
@@ -2785,13 +2785,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIIChlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_61c88366_7689_4814_b0c5_1f53aef1eebd
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_61c88366_7689_4814_b0c5_1f53aef1eebd
 :substance_61c88366_7689_4814_b0c5_1f53aef1eebd rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ;
                                                 skos:prefLabel "PostTransitionMetalOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_62a815b7_247b_4c48_b83c_d52044f57236
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_62a815b7_247b_4c48_b83c_d52044f57236
 :substance_62a815b7_247b_4c48_b83c_d52044f57236 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/102195117" ;
@@ -2801,14 +2801,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PDI"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_62be6033_d836_4fc9_92d4_bd8cf2a9ce3a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_62be6033_d836_4fc9_92d4_bd8cf2a9ce3a
 :substance_62be6033_d836_4fc9_92d4_bd8cf2a9ce3a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 skos:altLabel "Mg(TFSI)2"@en ;
                                                 skos:prefLabel "MagnesiumBistrifluoromethanesulfonylimide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6326d9bb_de83_4f60_beb3_3117280f8ab5
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6326d9bb_de83_4f60_beb3_3117280f8ab5
 :substance_6326d9bb_de83_4f60_beb3_3117280f8ab5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/29831" ;
@@ -2819,13 +2819,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ThreeMeTwoOxazolidinone"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_63788521_5764_4ee2_8d8a_ce4978682546
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_63788521_5764_4ee2_8d8a_ce4978682546
 :substance_63788521_5764_4ee2_8d8a_ce4978682546 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_015116fe_94ca_4be5_9d14_9d9457a47a72 ;
                                                 skos:prefLabel "IridiumSaltCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_63797ff9_c087_4033_a2e3_dd958e0b51e6
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_63797ff9_c087_4033_a2e3_dd958e0b51e6
 :substance_63797ff9_c087_4033_a2e3_dd958e0b51e6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1985595"@en ;
@@ -2838,7 +2838,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIISulfide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6400ba8f_97cf_4fa7_bc3b_aa2280bf5bea
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6400ba8f_97cf_4fa7_bc3b_aa2280bf5bea
 :substance_6400ba8f_97cf_4fa7_bc3b_aa2280bf5bea rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q113114521"@en ;
@@ -2850,7 +2850,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumDifluorophosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6405fdd6_9ba7_436a_a9f1_56fd6bd3610f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6405fdd6_9ba7_436a_a9f1_56fd6bd3610f
 :substance_6405fdd6_9ba7_436a_a9f1_56fd6bd3610f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q55583610"@en ;
@@ -2862,13 +2862,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIITetrafluoroborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6411d319_81a0_40f3_8e4d_09784d1c7644
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6411d319_81a0_40f3_8e4d_09784d1c7644
 :substance_6411d319_81a0_40f3_8e4d_09784d1c7644 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_61c88366_7689_4814_b0c5_1f53aef1eebd ;
                                                 skos:prefLabel "AluminiumOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_642ddaa3_0842_49c5_8bc9_2ae65f28da25
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_642ddaa3_0842_49c5_8bc9_2ae65f28da25
 :substance_642ddaa3_0842_49c5_8bc9_2ae65f28da25 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q6647969"@en ;
@@ -2881,7 +2881,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumSulfite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_64bbeab1_1e9a_481e_8aaf_6fa629071818
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_64bbeab1_1e9a_481e_8aaf_6fa629071818
 :substance_64bbeab1_1e9a_481e_8aaf_6fa629071818 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/14389160" ;
@@ -2892,7 +2892,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumHexafluorophosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_64d67eac_b2dc_45ad_9279_cff3a235e4e2
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_64d67eac_b2dc_45ad_9279_cff3a235e4e2
 :substance_64d67eac_b2dc_45ad_9279_cff3a235e4e2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a4d05f1_dd15_465b_8b44_704238e20813 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q419605"@en ;
@@ -2905,7 +2905,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIIIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_65032a2b_f5ce_44e4_8798_6bd989e6785f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_65032a2b_f5ce_44e4_8798_6bd989e6785f
 :substance_65032a2b_f5ce_44e4_8798_6bd989e6785f rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_bed1a22c_8b61_467a_86a0_d24c7b910653 ;
@@ -2919,7 +2919,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumHydroxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_651da334_c9a7_4658_998e_03533b5316f6
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_651da334_c9a7_4658_998e_03533b5316f6
 :substance_651da334_c9a7_4658_998e_03533b5316f6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q420300"@en ;
@@ -2932,14 +2932,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIIBromide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_656bd621_963a_4ff0_b606_7e5a952bda3a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_656bd621_963a_4ff0_b606_7e5a952bda3a
 :substance_656bd621_963a_4ff0_b606_7e5a952bda3a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 skos:altLabel "Zn(TFSI)2"@en ;
                                                 skos:prefLabel "ZincBistrifluoromethanesulfonylimide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_66ceb100_8123_4393_9b57_7e1899954600
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_66ceb100_8123_4393_9b57_7e1899954600
 :substance_66ceb100_8123_4393_9b57_7e1899954600 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/155293661" ;
@@ -2950,7 +2950,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumDifluorooxalatoborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6861354b_cb5b_415d_b970_9b11235b4775
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6861354b_cb5b_415d_b970_9b11235b4775
 :substance_6861354b_cb5b_415d_b970_9b11235b4775 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a4d05f1_dd15_465b_8b44_704238e20813 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q410985"@en ;
@@ -2963,7 +2963,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseII_IIIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_68c0876b_cb62_41cd_846d_95cc9d9a8733
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_68c0876b_cb62_41cd_846d_95cc9d9a8733
 :substance_68c0876b_cb62_41cd_846d_95cc9d9a8733 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a9a6507f_9c61_44d3_bd86_f1ebf763e150 ;
@@ -2977,13 +2977,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Silicon"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_68e4028b_0ec6_46da_8d1c_d00c644e8c82
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_68e4028b_0ec6_46da_8d1c_d00c644e8c82
 :substance_68e4028b_0ec6_46da_8d1c_d00c644e8c82 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ;
                                                 skos:prefLabel "AlkaliMetalElementalSubstance"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_68f9b85e_340f_46ec_96da_ebb6bd62f5fd
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_68f9b85e_340f_46ec_96da_ebb6bd62f5fd
 :substance_68f9b85e_340f_46ec_96da_ebb6bd62f5fd rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q15730218"@en ;
@@ -2994,7 +2994,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumChromiumOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6928f0e0_767e_4f33_a18e_e3041bf7d9e9
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6928f0e0_767e_4f33_a18e_e3041bf7d9e9
 :substance_6928f0e0_767e_4f33_a18e_e3041bf7d9e9 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q6748768"@en ;
@@ -3007,7 +3007,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIIPhosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6970bc02_dfe3_40c7_b20d_03c6cc0707bb
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6970bc02_dfe3_40c7_b20d_03c6cc0707bb
 :substance_6970bc02_dfe3_40c7_b20d_03c6cc0707bb rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_b978912b_19ef_4d46_8c91_2e3578b12670 ;
@@ -3020,7 +3020,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Thallium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_69c32d36_9bbc_4b93_9016_e73d24c24d71
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_69c32d36_9bbc_4b93_9016_e73d24c24d71
 :substance_69c32d36_9bbc_4b93_9016_e73d24c24d71 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q209444"@en ;
@@ -3034,7 +3034,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TwoMeTHF"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6a2432b3_abf1_4eba_825f_f0022ccba884
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6a2432b3_abf1_4eba_825f_f0022ccba884
 :substance_6a2432b3_abf1_4eba_825f_f0022ccba884 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409057"@en ;
@@ -3047,7 +3047,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumFluoride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6a733ffe_5a00_40c5_b9b2_52e339a4c804
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6a733ffe_5a00_40c5_b9b2_52e339a4c804
 :substance_6a733ffe_5a00_40c5_b9b2_52e339a4c804 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q417856"@en ;
@@ -3060,7 +3060,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIICarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6ae86cdf_2cd2_448a_8d6e_5a3bc5e12549
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6ae86cdf_2cd2_448a_8d6e_5a3bc5e12549
 :substance_6ae86cdf_2cd2_448a_8d6e_5a3bc5e12549 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q3680923"@en ;
@@ -3073,7 +3073,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincChlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6bf6b561_381d_4d69_bc25_dbdd322db18c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6bf6b561_381d_4d69_bc25_dbdd322db18c
 :substance_6bf6b561_381d_4d69_bc25_dbdd322db18c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q193054"@en ;
@@ -3086,13 +3086,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumSulfate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6c0cc397_d8c4_4473_a09f_1e5de568e0dd
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6c0cc397_d8c4_4473_a09f_1e5de568e0dd
 :substance_6c0cc397_d8c4_4473_a09f_1e5de568e0dd rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ;
                                                 skos:prefLabel "CarbonElementalSubstance"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6c4110ec_f268_48b5_bbb5_38fe95737122
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6c4110ec_f268_48b5_bbb5_38fe95737122
 :substance_6c4110ec_f268_48b5_bbb5_38fe95737122 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q3375145"@en ;
@@ -3105,27 +3105,27 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumPerchlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6c490298_2ce8_41e1_ac37_4b44faff2d44
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6c490298_2ce8_41e1_ac37_4b44faff2d44
 :substance_6c490298_2ce8_41e1_ac37_4b44faff2d44 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_edae7b22_461b_432b_b737_3c93feb69b0e ;
                                                 skos:prefLabel "AlkaliMetalSaltCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6cdc8512_d4f2_4904_8471_3121871d48e8
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6cdc8512_d4f2_4904_8471_3121871d48e8
 :substance_6cdc8512_d4f2_4904_8471_3121871d48e8 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 skos:altLabel "BOP"@en ;
                                                 skos:prefLabel "LithiumBisoxalatophosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6ce8569b_1367_4afd_954b_10eaccb8167c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6ce8569b_1367_4afd_954b_10eaccb8167c
 :substance_6ce8569b_1367_4afd_954b_10eaccb8167c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 skos:altLabel "Sr(DFOB)2"@en ;
                                                 skos:prefLabel "StrontiumDifluorooxalatoborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6cfae78f_ccca_40ec_b80d_ec09595cca95
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6cfae78f_ccca_40ec_b80d_ec09595cca95
 :substance_6cfae78f_ccca_40ec_b80d_ec09595cca95 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a4d05f1_dd15_465b_8b44_704238e20813 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q414669"@en ;
@@ -3138,7 +3138,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6d158508_abf0_4e10_beea_1d940da5fed1
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6d158508_abf0_4e10_beea_1d940da5fed1
 :substance_6d158508_abf0_4e10_beea_1d940da5fed1 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_78400dc0_97b0_4d59_8ea6_30bb703f428c ;
@@ -3152,7 +3152,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Iodine"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6d22feec_8b09_41ee_a98c_4eae316d445b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6d22feec_8b09_41ee_a98c_4eae316d445b
 :substance_6d22feec_8b09_41ee_a98c_4eae316d445b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q215281"@en ;
@@ -3165,7 +3165,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIINitrate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6d49be7e_bdd1_4d3b_bb95_d28047800a34
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6d49be7e_bdd1_4d3b_bb95_d28047800a34
 :substance_6d49be7e_bdd1_4d3b_bb95_d28047800a34 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4202653"@en ;
@@ -3178,7 +3178,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIIIodide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6dd0f601_64e2_4216_be62_cb80ee28f016
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6dd0f601_64e2_4216_be62_cb80ee28f016
 :substance_6dd0f601_64e2_4216_be62_cb80ee28f016 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204661"@en ;
@@ -3191,7 +3191,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincCarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6e5726c5_0589_4a2a_bdf4_3bece3121df5
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6e5726c5_0589_4a2a_bdf4_3bece3121df5
 :substance_6e5726c5_0589_4a2a_bdf4_3bece3121df5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q361627"@en ;
@@ -3204,7 +3204,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumPerchlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6ec58a26_3a58_4f9f_a1ff_7858e7668bf0
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6ec58a26_3a58_4f9f_a1ff_7858e7668bf0
 :substance_6ec58a26_3a58_4f9f_a1ff_7858e7668bf0 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407520"@en ;
@@ -3217,7 +3217,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumFluoride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_6ec62f7b_2168_423f_81d2_4555fa29415e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_6ec62f7b_2168_423f_81d2_4555fa29415e
 :substance_6ec62f7b_2168_423f_81d2_4555fa29415e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q15628157"@en ;
@@ -3230,7 +3230,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIIPerchlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_73ce979c_af17_4187_81a7_7206bde39ec6
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_73ce979c_af17_4187_81a7_7206bde39ec6
 :substance_73ce979c_af17_4187_81a7_7206bde39ec6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407392"@en ;
@@ -3243,7 +3243,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumNitrate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_73d4606c_7460_4a5c_9413_793bdf35753e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_73d4606c_7460_4a5c_9413_793bdf35753e
 :substance_73d4606c_7460_4a5c_9413_793bdf35753e rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_b978912b_19ef_4d46_8c91_2e3578b12670 ;
@@ -3256,7 +3256,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Gallium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_74bd7b49_4dd1_4093_8a4c_8b27a7998d05
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_74bd7b49_4dd1_4093_8a4c_8b27a7998d05
 :substance_74bd7b49_4dd1_4093_8a4c_8b27a7998d05 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q15425780"@en ;
@@ -3269,7 +3269,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIINitrite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_74d63619_6ed6_4571_9a82_e27576c1ef32
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_74d63619_6ed6_4571_9a82_e27576c1ef32
 :substance_74d63619_6ed6_4571_9a82_e27576c1ef32 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q309328"@en ;
@@ -3282,7 +3282,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumChlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_75322d4d_cdab_44c6_a8ea_5eca76bcfbd1
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_75322d4d_cdab_44c6_a8ea_5eca76bcfbd1
 :substance_75322d4d_cdab_44c6_a8ea_5eca76bcfbd1 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q3788669"@en ;
@@ -3298,7 +3298,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Tetraglyme"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_7550d4bb_59fd_41a3_aecb_4d45a03eaa28
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_7550d4bb_59fd_41a3_aecb_4d45a03eaa28
 :substance_7550d4bb_59fd_41a3_aecb_4d45a03eaa28 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q425473"@en ;
@@ -3310,7 +3310,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TartronicAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_761bcae6_b46b_4002_8601_474132fba6d8
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_761bcae6_b46b_4002_8601_474132fba6d8
 :substance_761bcae6_b46b_4002_8601_474132fba6d8 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_cac14194_2d5f_4fe6_b794_a9319f6d76ee ;
@@ -3324,7 +3324,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Helium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_761c90b7_61f7_495a_a5e7_a00afb14e41f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_761c90b7_61f7_495a_a5e7_a00afb14e41f
 :substance_761c90b7_61f7_495a_a5e7_a00afb14e41f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204828"@en ;
@@ -3337,7 +3337,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincIodide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_769bdc09_f533_4fde_bb53_20339d5bfcb7
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_769bdc09_f533_4fde_bb53_20339d5bfcb7
 :substance_769bdc09_f533_4fde_bb53_20339d5bfcb7 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -3351,7 +3351,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Dimethylformamide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_777a99d3_f2db_4c54_b093_85e3fbbe632d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_777a99d3_f2db_4c54_b093_85e3fbbe632d
 :substance_777a99d3_f2db_4c54_b093_85e3fbbe632d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q415500"@en ;
@@ -3364,13 +3364,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIIChloride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_78400dc0_97b0_4d59_8ea6_30bb703f428c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_78400dc0_97b0_4d59_8ea6_30bb703f428c
 :substance_78400dc0_97b0_4d59_8ea6_30bb703f428c rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ;
                                                 skos:prefLabel "ReactiveNonMetalElementalSubstance"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_788494aa_e502_4b8d_8e3a_883d14d3ed98
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_788494aa_e502_4b8d_8e3a_883d14d3ed98
 :substance_788494aa_e502_4b8d_8e3a_883d14d3ed98 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_8e5448fc_1916_4afb_9fd9_2489797f6922 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72461389"@en ;
@@ -3383,7 +3383,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperHydroxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_789fa169_2e2c_4a82_9c4a_aecebda6a9ab
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_789fa169_2e2c_4a82_9c4a_aecebda6a9ab
 :substance_789fa169_2e2c_4a82_9c4a_aecebda6a9ab rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7e716191_b301_4d63_bb6b_93323ffe51bf ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409762"@en ;
@@ -3396,7 +3396,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PolyacrylicAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_78a1367d_61b4_40a4_9c22_fdd0017f535f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_78a1367d_61b4_40a4_9c22_fdd0017f535f
 :substance_78a1367d_61b4_40a4_9c22_fdd0017f535f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q193213"@en ;
@@ -3408,7 +3408,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ButanoicAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_79220ea3_3426_47a0_9b41_33012d565fc2
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_79220ea3_3426_47a0_9b41_33012d565fc2
 :substance_79220ea3_3426_47a0_9b41_33012d565fc2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7e716191_b301_4d63_bb6b_93323ffe51bf ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q143429"@en ;
@@ -3417,7 +3417,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Polyethylene"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_79614448_5a32_49e2_a690_3b5ff59ba5b7
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_79614448_5a32_49e2_a690_3b5ff59ba5b7
 :substance_79614448_5a32_49e2_a690_3b5ff59ba5b7 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q419684"@en ;
@@ -3430,7 +3430,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIIBromide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_79b93232_d05a_445f_a365_659a64362dde
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_79b93232_d05a_445f_a365_659a64362dde
 :substance_79b93232_d05a_445f_a365_659a64362dde rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421174"@en ;
@@ -3443,7 +3443,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumFluoride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_7a613ca4_0c7b_463e_a48c_2e3b30b21c8a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_7a613ca4_0c7b_463e_a48c_2e3b30b21c8a
 :substance_7a613ca4_0c7b_463e_a48c_2e3b30b21c8a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q379885"@en ;
@@ -3456,7 +3456,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumCarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_7a757020_eecc_4dc1_afc7_55759911c772
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_7a757020_eecc_4dc1_afc7_55759911c772
 :substance_7a757020_eecc_4dc1_afc7_55759911c772 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dc68514f_b592_4e1b_a00f_fbb29f2fafbd ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/11161794" ;
@@ -3466,7 +3466,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Aquivion"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_7bc25dd0_8096_4ca0_98f3_03fb847f82e7
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_7bc25dd0_8096_4ca0_98f3_03fb847f82e7
 :substance_7bc25dd0_8096_4ca0_98f3_03fb847f82e7 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q190143"@en ;
@@ -3478,7 +3478,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MalicAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_7bebc661_c77b_4124_bed3_c2ac6346a2a6
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_7bebc661_c77b_4124_bed3_c2ac6346a2a6
 :substance_7bebc661_c77b_4124_bed3_c2ac6346a2a6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q419721"@en ;
@@ -3491,7 +3491,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumChlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_7beec353_bad9_46fc_a035_a76b131fb32b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_7beec353_bad9_46fc_a035_a76b131fb32b
 :substance_7beec353_bad9_46fc_a035_a76b131fb32b rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ;
                                                 owl:disjointWith :substance_cc155ed5_c60c_4d9f_bfad_fbf6b7c77e57 ;
@@ -3504,7 +3504,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Base"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_7c919833_aea5_4029_a0db_2289444ec2a5
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_7c919833_aea5_4029_a0db_2289444ec2a5
 :substance_7c919833_aea5_4029_a0db_2289444ec2a5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409701"@en ;
@@ -3517,14 +3517,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumBromide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_7cb7c122_995f_43d3_b419_b8a0d0fe8406
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_7cb7c122_995f_43d3_b419_b8a0d0fe8406
 :substance_7cb7c122_995f_43d3_b419_b8a0d0fe8406 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 skos:altLabel "Ba(FSI)2"@en ;
                                                 skos:prefLabel "BariumBisfluorosulfonylimide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_7d024df4_884b_4de3_b6f1_28af090356c3
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_7d024df4_884b_4de3_b6f1_28af090356c3
 :substance_7d024df4_884b_4de3_b6f1_28af090356c3 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q27292536"@en ;
@@ -3536,7 +3536,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIITetrafluoroborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_7dc738d6_74f2_489e_ae84_a6dbdf627f2e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_7dc738d6_74f2_489e_ae84_a6dbdf627f2e
 :substance_7dc738d6_74f2_489e_ae84_a6dbdf627f2e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b8c65e71_05de_4f07_acd8_a16938b550fd ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q23927502"@en ;
@@ -3549,19 +3549,19 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelOxideHydroxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84
 :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_fc93282d_cb35_4bab_81a8_78689ae59e5f ;
                                                 skos:prefLabel "BariumSaltCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_7e716191_b301_4d63_bb6b_93323ffe51bf
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_7e716191_b301_4d63_bb6b_93323ffe51bf
 :substance_7e716191_b301_4d63_bb6b_93323ffe51bf rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 skos:prefLabel "PolymerCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_7e9bbc33_c681_467a_b0d7_5de0e71230b4
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_7e9bbc33_c681_467a_b0d7_5de0e71230b4
 :substance_7e9bbc33_c681_467a_b0d7_5de0e71230b4 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q81982574"@en ;
@@ -3573,7 +3573,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Bis(oxalato)borate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_7fa9e820_f244_4929_a926_a6ebf85014ba
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_7fa9e820_f244_4929_a926_a6ebf85014ba
 :substance_7fa9e820_f244_4929_a926_a6ebf85014ba rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q55573807"@en ;
@@ -3585,13 +3585,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumTriflate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150
 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 ;
                                                 skos:prefLabel "AproticSolventCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_7fdf54d6_5503_4f83_8627_537805542c5b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_7fdf54d6_5503_4f83_8627_537805542c5b
 :substance_7fdf54d6_5503_4f83_8627_537805542c5b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411656"@en ;
@@ -3604,7 +3604,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumSulfide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8010a0fa_2147_41bc_a6b6_1da62fa7d939
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8010a0fa_2147_41bc_a6b6_1da62fa7d939
 :substance_8010a0fa_2147_41bc_a6b6_1da62fa7d939 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a639df56_1fb2_47f3_8069_c929b5a84b86 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409173"@en ;
@@ -3617,7 +3617,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "VanadiumVOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8018d7e8_c3f3_411e_adda_644bbd53338d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8018d7e8_c3f3_411e_adda_644bbd53338d
 :substance_8018d7e8_c3f3_411e_adda_644bbd53338d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_8f1af9c2_9b6d_44f4_8f55_70a4cd5f9dde ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4332819"@en ;
@@ -3628,7 +3628,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8069b9ca_4639_49c6_b182_fedff62869a1
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8069b9ca_4639_49c6_b182_fedff62869a1
 :substance_8069b9ca_4639_49c6_b182_fedff62869a1 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a4a5b239_d88e_4e03_a763_0bf2a3dd0f47 ;
@@ -3642,7 +3642,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Calcium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_815f5532_e1d0_48e5_bc2b_b3b7d018f032
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_815f5532_e1d0_48e5_bc2b_b3b7d018f032
 :substance_815f5532_e1d0_48e5_bc2b_b3b7d018f032 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409630"@en ;
@@ -3655,7 +3655,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIICarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_817d1989_4d6d_4c32_9951_85973afc538d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_817d1989_4d6d_4c32_9951_85973afc538d
 :substance_817d1989_4d6d_4c32_9951_85973afc538d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409298"@en ;
@@ -3669,13 +3669,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Dimethylformamide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_81b90332_8b8e_407b_a8fd_517306d56a59
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_81b90332_8b8e_407b_a8fd_517306d56a59
 :substance_81b90332_8b8e_407b_a8fd_517306d56a59 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ;
                                                 skos:prefLabel "SolventCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8267551d_7572_42f6_888d_96ff0c78f3aa
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8267551d_7572_42f6_888d_96ff0c78f3aa
 :substance_8267551d_7572_42f6_888d_96ff0c78f3aa rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q27273378"@en ;
@@ -3688,14 +3688,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumBistrifluoromethanesulfonylimide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_82d57014_0870_45f3_ab05_0f97c05b531d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_82d57014_0870_45f3_ab05_0f97c05b531d
 :substance_82d57014_0870_45f3_ab05_0f97c05b531d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 skos:altLabel "Mg(DFOB)2"@en ;
                                                 skos:prefLabel "MagnesiumDifluorooxalatoborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_83285f8c_bbf3_4548_9599_bc8c327fc099
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_83285f8c_bbf3_4548_9599_bc8c327fc099
 :substance_83285f8c_bbf3_4548_9599_bc8c327fc099 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_8e5448fc_1916_4afb_9fd9_2489797f6922 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q420717"@en ;
@@ -3708,7 +3708,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CadmiumHydroxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_835df324_98ae_44c2_a0ff_bd9142240b8c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_835df324_98ae_44c2_a0ff_bd9142240b8c
 :substance_835df324_98ae_44c2_a0ff_bd9142240b8c rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_f5b930f9_2f95_4268_993c_ff6b57ae7691 ;
@@ -3722,7 +3722,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "HydrogenIodide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8385c3c4_5906_48f6_b6b6_4bb60dccc27a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8385c3c4_5906_48f6_b6b6_4bb60dccc27a
 :substance_8385c3c4_5906_48f6_b6b6_4bb60dccc27a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421748"@en ;
@@ -3737,7 +3737,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Dichloromethane"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_843697d9_5863_4959_9163_5b58dba6a3f0
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_843697d9_5863_4959_9163_5b58dba6a3f0
 :substance_843697d9_5863_4959_9163_5b58dba6a3f0 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q419893"@en ;
@@ -3750,7 +3750,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIISulfide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_846f0b5b_cdf5_4a12_938b_75d9312e02b3
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_846f0b5b_cdf5_4a12_938b_75d9312e02b3
 :substance_846f0b5b_cdf5_4a12_938b_75d9312e02b3 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q416969"@en ;
@@ -3763,7 +3763,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumAcetate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_847590b4_fae5_4f57_b1b0_1bb545528152
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_847590b4_fae5_4f57_b1b0_1bb545528152
 :substance_847590b4_fae5_4f57_b1b0_1bb545528152 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q278387"@en ;
@@ -3776,7 +3776,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumPhosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_848003a2_71ee_4967_8039_354c907ec7f4
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_848003a2_71ee_4967_8039_354c907ec7f4
 :substance_848003a2_71ee_4967_8039_354c907ec7f4 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_28754642_a1ed_4f39_8b00_2c7857336bab ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q190077"@en ;
@@ -3789,7 +3789,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8522bd08_3855_4e4b_bca0_30923a40de88
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8522bd08_3855_4e4b_bca0_30923a40de88
 :substance_8522bd08_3855_4e4b_bca0_30923a40de88 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_68e4028b_0ec6_46da_8d1c_d00c644e8c82 ;
@@ -3802,7 +3802,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Caesium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_859210f4_f4ac_445d_841c_74e3fbe74c3e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_859210f4_f4ac_445d_841c_74e3fbe74c3e
 :substance_859210f4_f4ac_445d_841c_74e3fbe74c3e rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -3815,7 +3815,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Tungsten"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_860eab87_6711_4b5b_90ca_50b6f4da7f67
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_860eab87_6711_4b5b_90ca_50b6f4da7f67
 :substance_860eab87_6711_4b5b_90ca_50b6f4da7f67 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -3829,13 +3829,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Sulfolane"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_878a0e2f_12ba_484e_8197_75e57139d207
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_878a0e2f_12ba_484e_8197_75e57139d207
 :substance_878a0e2f_12ba_484e_8197_75e57139d207 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 ;
                                                 skos:prefLabel "ProticSolventCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_881dd19c_814c_4c58_9e67_f9c2494fec11
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_881dd19c_814c_4c58_9e67_f9c2494fec11
 :substance_881dd19c_814c_4c58_9e67_f9c2494fec11 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407510"@en ;
@@ -3848,13 +3848,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumSulfide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_88748886_9b7c_4df0_91eb_fe91ecc1b9cd
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_88748886_9b7c_4df0_91eb_fe91ecc1b9cd
 :substance_88748886_9b7c_4df0_91eb_fe91ecc1b9cd rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "ChromiumOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_88b6445a_0445_483f_88f4_6b910e901c08
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_88b6445a_0445_483f_88f4_6b910e901c08
 :substance_88b6445a_0445_483f_88f4_6b910e901c08 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_68e4028b_0ec6_46da_8d1c_d00c644e8c82 ;
@@ -3867,7 +3867,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Potassium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_88d380f4_1207_4a30_a117_8472bb3d1d81
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_88d380f4_1207_4a30_a117_8472bb3d1d81
 :substance_88d380f4_1207_4a30_a117_8472bb3d1d81 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4918589"@en ;
@@ -3880,7 +3880,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Bistriflimide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_89228db4_7491_40f1_bd25_c87e459a2d20
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_89228db4_7491_40f1_bd25_c87e459a2d20
 :substance_89228db4_7491_40f1_bd25_c87e459a2d20 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q419503"@en ;
@@ -3893,7 +3893,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumPhosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_89898e91_c4c7_4057_8040_965d1776d2ba
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_89898e91_c4c7_4057_8040_965d1776d2ba
 :substance_89898e91_c4c7_4057_8040_965d1776d2ba rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q314036"@en ;
@@ -3906,7 +3906,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumChloride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_899debc5_ad7c_4f0a_a68c_47fedca57364
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_899debc5_ad7c_4f0a_a68c_47fedca57364
 :substance_899debc5_ad7c_4f0a_a68c_47fedca57364 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407806"@en ;
@@ -3919,7 +3919,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumSulfite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_89fd13e8_8061_41da_83f4_634144116425
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_89fd13e8_8061_41da_83f4_634144116425
 :substance_89fd13e8_8061_41da_83f4_634144116425 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -3932,7 +3932,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Iron"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8a253be9_75a6_4da2_b875_4454d5aebef3
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8a253be9_75a6_4da2_b875_4454d5aebef3
 :substance_8a253be9_75a6_4da2_b875_4454d5aebef3 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q7624768"@en ;
@@ -3945,7 +3945,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumChlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8a897ed1_a611_46bf_8252_502428a0bff7
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8a897ed1_a611_46bf_8252_502428a0bff7
 :substance_8a897ed1_a611_46bf_8252_502428a0bff7 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407258"@en ;
@@ -3958,7 +3958,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumSulfate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8ab4c789_bad4_4b36_9f54_d8c6e9e7b5b2
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8ab4c789_bad4_4b36_9f54_d8c6e9e7b5b2
 :substance_8ab4c789_bad4_4b36_9f54_d8c6e9e7b5b2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q416913"@en ;
@@ -3970,7 +3970,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumSulfide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8ab6b726_e711_41d7_b237_b21094383239
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8ab6b726_e711_41d7_b237_b21094383239
 :substance_8ab6b726_e711_41d7_b237_b21094383239 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/59687871" ;
@@ -3981,7 +3981,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Bis(malonato)borate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8aeab71f_c07f_4eb6_9652_08ee27c29ffc
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8aeab71f_c07f_4eb6_9652_08ee27c29ffc
 :substance_8aeab71f_c07f_4eb6_9652_08ee27c29ffc rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q417658"@en ;
@@ -3994,7 +3994,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumSulfide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8afd2477_9c49_4465_9910_6103732a3318
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8afd2477_9c49_4465_9910_6103732a3318
 :substance_8afd2477_9c49_4465_9910_6103732a3318 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4096880"@en ;
@@ -4007,7 +4007,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIBromide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8b02cecd_75f9_47d6_8826_55c1a42f1c42
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8b02cecd_75f9_47d6_8826_55c1a42f1c42
 :substance_8b02cecd_75f9_47d6_8826_55c1a42f1c42 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q416904"@en ;
@@ -4020,13 +4020,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumBromide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8c40be1f_0931_4db9_832f_cb63556f6a5a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8c40be1f_0931_4db9_832f_cb63556f6a5a
 :substance_8c40be1f_0931_4db9_832f_cb63556f6a5a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_edae7b22_461b_432b_b737_3c93feb69b0e ;
                                                 skos:prefLabel "PostTransitionMetalSaltCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8c49b4a2_00e2_421e_97af_9dde2a59ac69
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8c49b4a2_00e2_421e_97af_9dde2a59ac69
 :substance_8c49b4a2_00e2_421e_97af_9dde2a59ac69 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2396092"@en ;
@@ -4039,7 +4039,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumSulfite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8c783453_0a52_4c20_9687_2b6ce2b95762
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8c783453_0a52_4c20_9687_2b6ce2b95762
 :substance_8c783453_0a52_4c20_9687_2b6ce2b95762 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1765041"@en ;
@@ -4052,7 +4052,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumSulfide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8cbdf192_69bf_45cc_a570_95bf69fd8f91
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8cbdf192_69bf_45cc_a570_95bf69fd8f91
 :substance_8cbdf192_69bf_45cc_a570_95bf69fd8f91 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q808224"@en ;
@@ -4064,7 +4064,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumPhosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8ce10627_f9f3_4520_a619_b407877e263b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8ce10627_f9f3_4520_a619_b407877e263b
 :substance_8ce10627_f9f3_4520_a619_b407877e263b rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a9a6507f_9c61_44d3_bd86_f1ebf763e150 ;
@@ -4078,7 +4078,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Tellurium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8cf9ae58_147a_4fb3_a3c8_972bb2fdcca0
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8cf9ae58_147a_4fb3_a3c8_972bb2fdcca0
 :substance_8cf9ae58_147a_4fb3_a3c8_972bb2fdcca0 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q419690"@en ;
@@ -4091,7 +4091,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIIFluoride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8d866be8_fec3_4253_a388_ca6005fd9c85
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8d866be8_fec3_4253_a388_ca6005fd9c85
 :substance_8d866be8_fec3_4253_a388_ca6005fd9c85 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q412492"@en ;
@@ -4104,7 +4104,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumChlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8dd87ac5_a8e1_4228_93bb_189e442fa71b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8dd87ac5_a8e1_4228_93bb_189e442fa71b
 :substance_8dd87ac5_a8e1_4228_93bb_189e442fa71b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/14389155" ;
@@ -4115,19 +4115,19 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumHexafluorophosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8e5448fc_1916_4afb_9fd9_2489797f6922
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8e5448fc_1916_4afb_9fd9_2489797f6922
 :substance_8e5448fc_1916_4afb_9fd9_2489797f6922 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7beec353_bad9_46fc_a035_a76b131fb32b ;
                                                 skos:prefLabel "WeakBaseCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8f1af9c2_9b6d_44f4_8f55_70a4cd5f9dde
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8f1af9c2_9b6d_44f4_8f55_70a4cd5f9dde
 :substance_8f1af9c2_9b6d_44f4_8f55_70a4cd5f9dde rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_61c88366_7689_4814_b0c5_1f53aef1eebd ;
                                                 skos:prefLabel "IndiumOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8f7dd877_5ad0_48f1_bbec_84153d8215f4
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8f7dd877_5ad0_48f1_bbec_84153d8215f4
 :substance_8f7dd877_5ad0_48f1_bbec_84153d8215f4 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_b978912b_19ef_4d46_8c91_2e3578b12670 ;
@@ -4140,7 +4140,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Aluminium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8f857eb2_7cc8_4294_954d_e69f2842c084
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8f857eb2_7cc8_4294_954d_e69f2842c084
 :substance_8f857eb2_7cc8_4294_954d_e69f2842c084 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -4153,7 +4153,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Cobalt"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8f867fdb_27b7_4d6f_9628_98da5afcad5b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8f867fdb_27b7_4d6f_9628_98da5afcad5b
 :substance_8f867fdb_27b7_4d6f_9628_98da5afcad5b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7e716191_b301_4d63_bb6b_93323ffe51bf ,
                                                                 :substance_961f7671_8708_4ce3_9c7d_79444adba9c0 ;
@@ -4163,7 +4163,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PolyvinylAlcohol"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_8fd9909b_b99a_41a8_be0e_19f6717e5c2f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_8fd9909b_b99a_41a8_be0e_19f6717e5c2f
 :substance_8fd9909b_b99a_41a8_be0e_19f6717e5c2f rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72476692"@en ;
@@ -4175,7 +4175,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TwoFluoropyridine"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_904b81d8_7d9c_45f4_95d7_e27ff9cebf17
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_904b81d8_7d9c_45f4_95d7_e27ff9cebf17
 :substance_904b81d8_7d9c_45f4_95d7_e27ff9cebf17 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_bed1a22c_8b61_467a_86a0_d24c7b910653 ;
@@ -4189,7 +4189,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumHydroxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_90f71119_f476_4033_b6ee_6342680322e5
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_90f71119_f476_4033_b6ee_6342680322e5
 :substance_90f71119_f476_4033_b6ee_6342680322e5 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -4202,7 +4202,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Cadmium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_91890364_2be0_4333_ae45_f619cbf2d078
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_91890364_2be0_4333_ae45_f619cbf2d078
 :substance_91890364_2be0_4333_ae45_f619cbf2d078 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204954"@en ;
@@ -4215,7 +4215,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincSulfate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_92a60b4f_7abf_46f9_824b_47ff7aa09c15
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_92a60b4f_7abf_46f9_824b_47ff7aa09c15
 :substance_92a60b4f_7abf_46f9_824b_47ff7aa09c15 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q18212007"@en ;
@@ -4228,7 +4228,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIIPerchlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_945c68da_3baf_4da6_b794_dca7aebc4ca7
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_945c68da_3baf_4da6_b794_dca7aebc4ca7
 :substance_945c68da_3baf_4da6_b794_dca7aebc4ca7 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -4242,7 +4242,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Dimethylpropyleneurea"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_94af35ef_9e0d_4e4d_b794_ee0a14706831
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_94af35ef_9e0d_4e4d_b794_ee0a14706831
 :substance_94af35ef_9e0d_4e4d_b794_ee0a14706831 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407821"@en ;
@@ -4255,7 +4255,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIISulfate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_9541345c_da1f_4f5b_bf89_09a4dfdb43cb
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_9541345c_da1f_4f5b_bf89_09a4dfdb43cb
 :substance_9541345c_da1f_4f5b_bf89_09a4dfdb43cb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421215"@en ;
@@ -4268,7 +4268,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIISulfide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_95503d46_8343_4054_aa34_f0169ae0dbed
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_95503d46_8343_4054_aa34_f0169ae0dbed
 :substance_95503d46_8343_4054_aa34_f0169ae0dbed rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q424250"@en ;
@@ -4281,7 +4281,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumSulfide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_957cb95c_00a1_4cf1_97b9_0d3b4f89f27e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_957cb95c_00a1_4cf1_97b9_0d3b4f89f27e
 :substance_957cb95c_00a1_4cf1_97b9_0d3b4f89f27e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q24237111"@en ;
@@ -4293,13 +4293,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIINitrite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_961f7671_8708_4ce3_9c7d_79444adba9c0
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_961f7671_8708_4ce3_9c7d_79444adba9c0
 :substance_961f7671_8708_4ce3_9c7d_79444adba9c0 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 skos:prefLabel "Alcohol"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_97439fbb_155f_433d_9edd_d510cd491f24
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_97439fbb_155f_433d_9edd_d510cd491f24
 :substance_97439fbb_155f_433d_9edd_d510cd491f24 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/158503887" ;
@@ -4309,7 +4309,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumNickelPhosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_97932144_ab3b_4206_8238_ee8ea9b3327e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_97932144_ab3b_4206_8238_ee8ea9b3327e
 :substance_97932144_ab3b_4206_8238_ee8ea9b3327e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q15631940"@en ;
@@ -4322,7 +4322,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIIPerchlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_98c358bd_7326_4ce7_b46c_2a78f3fd10eb
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_98c358bd_7326_4ce7_b46c_2a78f3fd10eb
 :substance_98c358bd_7326_4ce7_b46c_2a78f3fd10eb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q865952"@en ;
@@ -4337,7 +4337,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Diglyme"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_994bfc80_9645_4178_9b1e_38513010206c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_994bfc80_9645_4178_9b1e_38513010206c
 :substance_994bfc80_9645_4178_9b1e_38513010206c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/166825" ;
@@ -4348,7 +4348,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumNitrite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_99789d57_25ea_4b0d_bebb_45012a85e9c4
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_99789d57_25ea_4b0d_bebb_45012a85e9c4
 :substance_99789d57_25ea_4b0d_bebb_45012a85e9c4 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q206778"@en ;
@@ -4361,7 +4361,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SulfurousAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_99e61c41_9038_418a_b98c_ab225bd6bec1
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_99e61c41_9038_418a_b98c_ab225bd6bec1
 :substance_99e61c41_9038_418a_b98c_ab225bd6bec1 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -4374,7 +4374,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Ruthenium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_9ad998c9_f5dd_48ff_af9f_b03d7b0211b4
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_9ad998c9_f5dd_48ff_af9f_b03d7b0211b4
 :substance_9ad998c9_f5dd_48ff_af9f_b03d7b0211b4 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421781"@en ;
@@ -4387,7 +4387,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIIChloride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_9b92f5b9_a477_4267_bf68_769c995e6e83
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_9b92f5b9_a477_4267_bf68_769c995e6e83
 :substance_9b92f5b9_a477_4267_bf68_769c995e6e83 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_b978912b_19ef_4d46_8c91_2e3578b12670 ;
@@ -4400,7 +4400,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Indium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_9bd78e1c_a4dc_41b6_8013_adb51df1ffdc
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_9bd78e1c_a4dc_41b6_8013_adb51df1ffdc
 :substance_9bd78e1c_a4dc_41b6_8013_adb51df1ffdc rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -4413,7 +4413,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Zinc"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_9c12a04b_1133_4ee0_ad24_26c835f12d1f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_9c12a04b_1133_4ee0_ad24_26c835f12d1f
 :substance_9c12a04b_1133_4ee0_ad24_26c835f12d1f rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_78400dc0_97b0_4d59_8ea6_30bb703f428c ;
@@ -4427,7 +4427,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Sulfur"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_9c9ceee7_2470_4d05_89e7_28fb93108e38
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_9c9ceee7_2470_4d05_89e7_28fb93108e38
 :substance_9c9ceee7_2470_4d05_89e7_28fb93108e38 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_b978912b_19ef_4d46_8c91_2e3578b12670 ;
@@ -4440,7 +4440,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Tin"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_9d130518_2b84_435f_8632_039d43d2ef5d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_9d130518_2b84_435f_8632_039d43d2ef5d
 :substance_9d130518_2b84_435f_8632_039d43d2ef5d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q422597"@en ;
@@ -4452,7 +4452,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "HexanoicAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_9d25dbcc_5fc2_4281_ace2_335a1b5da266
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_9d25dbcc_5fc2_4281_ace2_335a1b5da266
 :substance_9d25dbcc_5fc2_4281_ace2_335a1b5da266 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc9ba950_96c1_4ac2_a0e2_1c4f7f001b1d ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q410749"@en ;
@@ -4465,14 +4465,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIVOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_9d6b0e6b_b51f_40a8_bc9d_1418ea5356b1
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_9d6b0e6b_b51f_40a8_bc9d_1418ea5356b1
 :substance_9d6b0e6b_b51f_40a8_bc9d_1418ea5356b1 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 skos:altLabel "Ca(BOB)2"@en ;
                                                 skos:prefLabel "CalciumBisoxalatoborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_9d6b7dd4_6276_4e57_bdbb_228823821995
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_9d6b7dd4_6276_4e57_bdbb_228823821995
 :substance_9d6b7dd4_6276_4e57_bdbb_228823821995 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72514132"@en ;
@@ -4483,7 +4483,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MethoxyTrimethylSilane"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_9d7497bb_fe1b_4b9f_808b_f6df310dd900
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_9d7497bb_fe1b_4b9f_808b_f6df310dd900
 :substance_9d7497bb_fe1b_4b9f_808b_f6df310dd900 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q288266"@en ;
@@ -4496,7 +4496,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumSulfate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_9da78aea_d436_40e2_a68f_c3dee32b825e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_9da78aea_d436_40e2_a68f_c3dee32b825e
 :substance_9da78aea_d436_40e2_a68f_c3dee32b825e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_6c0cc397_d8c4_4473_a09f_1e5de568e0dd ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q947047"@en ;
@@ -4509,7 +4509,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CarbonMonofluoride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_9db045a6_0104_4b2d_85ce_9610e99c7fc4
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_9db045a6_0104_4b2d_85ce_9610e99c7fc4
 :substance_9db045a6_0104_4b2d_85ce_9610e99c7fc4 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q205374"@en ;
@@ -4522,7 +4522,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumFluoride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_9e25f281_5f69_4300_82a7_9025ea2061c4
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_9e25f281_5f69_4300_82a7_9025ea2061c4
 :substance_9e25f281_5f69_4300_82a7_9025ea2061c4 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q423000"@en ;
@@ -4536,7 +4536,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Trichlorofluoromethane"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_9f40a798_f293_487a_a263_fc703778ae25
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_9f40a798_f293_487a_a263_fc703778ae25
 :substance_9f40a798_f293_487a_a263_fc703778ae25 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q55164806"@en ;
@@ -4548,7 +4548,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIITetrafluoroborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_9fb92a20_082e_4d43_83d0_4b2aba8345ca
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_9fb92a20_082e_4d43_83d0_4b2aba8345ca
 :substance_9fb92a20_082e_4d43_83d0_4b2aba8345ca rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q211891"@en ;
@@ -4561,7 +4561,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NitrousAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_a021f565_c3de_46b7_b46b_be4c7849e1ea
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_a021f565_c3de_46b7_b46b_be4c7849e1ea
 :substance_a021f565_c3de_46b7_b46b_be4c7849e1ea rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q425450"@en ;
@@ -4574,7 +4574,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumCarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_a065f68b_99ed_4bdd_b568_13158ba1731f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_a065f68b_99ed_4bdd_b568_13158ba1731f
 :substance_a065f68b_99ed_4bdd_b568_13158ba1731f rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -4588,20 +4588,20 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Acetone"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746
 :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_fc93282d_cb35_4bab_81a8_78689ae59e5f ;
                                                 skos:prefLabel "StrontiumSaltCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_a092c93d_1d03_4d74_b0d7_7ed51b0a3eca
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_a092c93d_1d03_4d74_b0d7_7ed51b0a3eca
 :substance_a092c93d_1d03_4d74_b0d7_7ed51b0a3eca rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 skos:altLabel "a(DFOB)2"@en ;
                                                 skos:prefLabel "BariumDifluorooxalatoborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_a16a1bae_7844_42fd_bb6d_979195d6c933
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_a16a1bae_7844_42fd_bb6d_979195d6c933
 :substance_a16a1bae_7844_42fd_bb6d_979195d6c933 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_68e4028b_0ec6_46da_8d1c_d00c644e8c82 ;
@@ -4614,7 +4614,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Sodium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_a2b46543_4d0f_488a_b51a_7ed3a4149170
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_a2b46543_4d0f_488a_b51a_7ed3a4149170
 :substance_a2b46543_4d0f_488a_b51a_7ed3a4149170 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_6411d319_81a0_40f3_8e4d_09784d1c7644 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q177342"@en ;
@@ -4627,7 +4627,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_a36cbc8b_f4a8_45ef_99da_748d840f51d4
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_a36cbc8b_f4a8_45ef_99da_748d840f51d4
 :substance_a36cbc8b_f4a8_45ef_99da_748d840f51d4 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -4640,13 +4640,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Rhenium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_a4a5b239_d88e_4e03_a763_0bf2a3dd0f47
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_a4a5b239_d88e_4e03_a763_0bf2a3dd0f47
 :substance_a4a5b239_d88e_4e03_a763_0bf2a3dd0f47 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ;
                                                 skos:prefLabel "AlkalineEarthMetalElementalSubstance"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_a4e68f0a_07b5_4899_b570_f3a70a07b5b3
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_a4e68f0a_07b5_4899_b570_f3a70a07b5b3
 :substance_a4e68f0a_07b5_4899_b570_f3a70a07b5b3 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/86649651" ;
@@ -4657,13 +4657,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincHexafluorophosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_a639df56_1fb2_47f3_8069_c929b5a84b86
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_a639df56_1fb2_47f3_8069_c929b5a84b86
 :substance_a639df56_1fb2_47f3_8069_c929b5a84b86 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "VandaiumOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_a67cda39_f3ac_4983_a93d_07a2067b5901
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_a67cda39_f3ac_4983_a93d_07a2067b5901
 :substance_a67cda39_f3ac_4983_a93d_07a2067b5901 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/26286" ;
@@ -4674,7 +4674,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumTetrafluoroborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_a6d037e0_233e_4fb2_ba36_2f5b9263a450
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_a6d037e0_233e_4fb2_ba36_2f5b9263a450
 :substance_a6d037e0_233e_4fb2_ba36_2f5b9263a450 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -4688,7 +4688,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Tetrahydrofuran"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_a6feec60_5fe7_4687_b427_3bf2ed06008d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_a6feec60_5fe7_4687_b427_3bf2ed06008d
 :substance_a6feec60_5fe7_4687_b427_3bf2ed06008d rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -4702,7 +4702,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Dichloromethane"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_a84adfaa_e17e_4325_86d3_208d418e9956
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_a84adfaa_e17e_4325_86d3_208d418e9956
 :substance_a84adfaa_e17e_4325_86d3_208d418e9956 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q184373"@en ;
@@ -4715,7 +4715,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumNitrate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_a8a48b58_d2ea_441c_b4ea_1b3ba65d9545
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_a8a48b58_d2ea_441c_b4ea_1b3ba65d9545
 :substance_a8a48b58_d2ea_441c_b4ea_1b3ba65d9545 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q182329"@en ;
@@ -4728,13 +4728,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumNitrate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_a9218f8f_2e80_497e_b968_b4947cf21802
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_a9218f8f_2e80_497e_b968_b4947cf21802
 :substance_a9218f8f_2e80_497e_b968_b4947cf21802 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ;
                                                 skos:prefLabel "ZirconiumOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_a95f6717_7edd_4901_9fbd_c0e39d95da65
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_a95f6717_7edd_4901_9fbd_c0e39d95da65
 :substance_a95f6717_7edd_4901_9fbd_c0e39d95da65 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q28453483"@en ;
@@ -4747,13 +4747,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumChloride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_a9a6507f_9c61_44d3_bd86_f1ebf763e150
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_a9a6507f_9c61_44d3_bd86_f1ebf763e150
 :substance_a9a6507f_9c61_44d3_bd86_f1ebf763e150 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ;
                                                 skos:prefLabel "MetalloidElementalSubstance"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_aa7169ea_b61f_4b4c_a67b_50f2aea8bbf6
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_aa7169ea_b61f_4b4c_a67b_50f2aea8bbf6
 :substance_aa7169ea_b61f_4b4c_a67b_50f2aea8bbf6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q410174"@en ;
@@ -4766,7 +4766,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumCarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_aa740290_2568_4b54_9d0f_2edc88e333ba
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_aa740290_2568_4b54_9d0f_2edc88e333ba
 :substance_aa740290_2568_4b54_9d0f_2edc88e333ba rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f5b930f9_2f95_4268_993c_ff6b57ae7691 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2409"@en ;
@@ -4779,7 +4779,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "HydrogenChloride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_aa8e9cc4_5f66_4307_b1c8_26fac7653a90
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_aa8e9cc4_5f66_4307_b1c8_26fac7653a90
 :substance_aa8e9cc4_5f66_4307_b1c8_26fac7653a90 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q3042400"@en ;
@@ -4792,13 +4792,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumIronPhosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4
 :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_edae7b22_461b_432b_b737_3c93feb69b0e ;
                                                 skos:prefLabel "AmmoniumSaltCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ab34d4a3_a5c8_4318_9b7d_0608e2149398
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ab34d4a3_a5c8_4318_9b7d_0608e2149398
 :substance_ab34d4a3_a5c8_4318_9b7d_0608e2149398 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421133"@en ;
@@ -4811,14 +4811,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumAcetate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ab3606c2_a1e3_4e40_b427_766c586b5f77
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ab3606c2_a1e3_4e40_b427_766c586b5f77
 :substance_ab3606c2_a1e3_4e40_b427_766c586b5f77 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 skos:altLabel "Sr(TFOB)2"@en ;
                                                 skos:prefLabel "StrontiumTrifluoromethanesulfonyloxalatoborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_abeadd58_520a_49b1_b89a_f668f00cb7ff
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_abeadd58_520a_49b1_b89a_f668f00cb7ff
 :substance_abeadd58_520a_49b1_b89a_f668f00cb7ff rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2546"@en ;
@@ -4831,7 +4831,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumBromide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ac358c17_0cb7_4472_9c7a_fea07ae09e58
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ac358c17_0cb7_4472_9c7a_fea07ae09e58
 :substance_ac358c17_0cb7_4472_9c7a_fea07ae09e58 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_878a0e2f_12ba_484e_8197_75e57139d207 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2270"@en ;
@@ -4844,7 +4844,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Benzene"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_acb8c003_6453_49d8_ad93_456cc99d5d10
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_acb8c003_6453_49d8_ad93_456cc99d5d10
 :substance_acb8c003_6453_49d8_ad93_456cc99d5d10 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f5b930f9_2f95_4268_993c_ff6b57ae7691 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2447"@en ;
@@ -4857,7 +4857,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "HydrogenBromide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_acdb232f_8041_4e11_8a11_5db2d2baae4d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_acdb232f_8041_4e11_8a11_5db2d2baae4d
 :substance_acdb232f_8041_4e11_8a11_5db2d2baae4d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q3991823"@en ;
@@ -4870,7 +4870,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumTitanate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ace24dd1_189a_4b0e_b110_7aad94309d15
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ace24dd1_189a_4b0e_b110_7aad94309d15
 :substance_ace24dd1_189a_4b0e_b110_7aad94309d15 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204639"@en ;
@@ -4883,14 +4883,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincAcetate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ad1fe482_6d88_4207_b1e5_ef01b68bec97
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ad1fe482_6d88_4207_b1e5_ef01b68bec97
 :substance_ad1fe482_6d88_4207_b1e5_ef01b68bec97 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 skos:altLabel "Ba(BOB)2"@en ;
                                                 skos:prefLabel "BariumBisoxalatoborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ad5895fb_8fc3_42fc_8e9c_5c4723777624
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ad5895fb_8fc3_42fc_8e9c_5c4723777624
 :substance_ad5895fb_8fc3_42fc_8e9c_5c4723777624 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a639df56_1fb2_47f3_8069_c929b5a84b86 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1966236"@en ;
@@ -4903,7 +4903,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "VanadiumIIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ada25a02_551d_4193_a944_57dda99ebb5b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ada25a02_551d_4193_a944_57dda99ebb5b
 :substance_ada25a02_551d_4193_a944_57dda99ebb5b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409319"@en ;
@@ -4916,7 +4916,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumFluoride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_aef7d4bb_0b44_4974_84a0_e2729f5f2bef
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_aef7d4bb_0b44_4974_84a0_e2729f5f2bef
 :substance_aef7d4bb_0b44_4974_84a0_e2729f5f2bef rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_88748886_9b7c_4df0_91eb_fe91ecc1b9cd ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407905"@en ;
@@ -4928,7 +4928,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ChromiumIIIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_af1422d5_f626_49e4_9302_cb94e6d5ff7b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_af1422d5_f626_49e4_9302_cb94e6d5ff7b
 :substance_af1422d5_f626_49e4_9302_cb94e6d5ff7b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q417080"@en ;
@@ -4941,7 +4941,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumFluoride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_af9dfae5_00b8_497a_a59a_83f0c5687734
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_af9dfae5_00b8_497a_a59a_83f0c5687734
 :substance_af9dfae5_00b8_497a_a59a_83f0c5687734 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -4954,7 +4954,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Yttrium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b01771a9_218a_4b01_b20f_4021cfa0b7d5
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b01771a9_218a_4b01_b20f_4021cfa0b7d5
 :substance_b01771a9_218a_4b01_b20f_4021cfa0b7d5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/22173729" ;
@@ -4964,13 +4964,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumManganesePhosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b07a5287_67d1_4f4f_9640_e0146f713a6c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b07a5287_67d1_4f4f_9640_e0146f713a6c
 :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_edae7b22_461b_432b_b737_3c93feb69b0e ;
                                                 skos:prefLabel "ZincSaltCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b0948006_869b_4426_b2b7_30b5c5112e3e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b0948006_869b_4426_b2b7_30b5c5112e3e
 :substance_b0948006_869b_4426_b2b7_30b5c5112e3e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q24629264"@en ;
@@ -4983,7 +4983,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIIPerchlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b0abf2a1_540e_42fc_b3cf_f5a8a43e591d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b0abf2a1_540e_42fc_b3cf_f5a8a43e591d
 :substance_b0abf2a1_540e_42fc_b3cf_f5a8a43e591d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q47512"@en ;
@@ -4996,7 +4996,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AceticAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b1c9078e_f001_4a8a_a56d_2c6444a18201
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b1c9078e_f001_4a8a_a56d_2c6444a18201
 :substance_b1c9078e_f001_4a8a_a56d_2c6444a18201 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q265414"@en ;
@@ -5009,7 +5009,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumChloride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b1cf27b3_b657_430e_80e9_c506cc522cbb
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b1cf27b3_b657_430e_80e9_c506cc522cbb
 :substance_b1cf27b3_b657_430e_80e9_c506cc522cbb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q413552"@en ;
@@ -5022,7 +5022,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "GlyoxylicAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b258c23a_748e_4f92_9d55_354b92c298df
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b258c23a_748e_4f92_9d55_354b92c298df
 :substance_b258c23a_748e_4f92_9d55_354b92c298df rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q159683"@en ;
@@ -5034,7 +5034,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CitricAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b3130004_ad93_4cff_84b5_1f8d77b97ecb
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b3130004_ad93_4cff_84b5_1f8d77b97ecb
 :substance_b3130004_ad93_4cff_84b5_1f8d77b97ecb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421083"@en ;
@@ -5047,13 +5047,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumNitrate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b325bdd7_0adf_4522_a4ef_20cd6929e094
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b325bdd7_0adf_4522_a4ef_20cd6929e094
 :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 skos:prefLabel "OrganicAcidCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b3708b26_f2dc_4a68_97c3_fced02c8d0e2
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b3708b26_f2dc_4a68_97c3_fced02c8d0e2
 :substance_b3708b26_f2dc_4a68_97c3_fced02c8d0e2 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -5067,7 +5067,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Acetonitrile"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b3815a7f_f64a_48f6_b0ce_d0032578c699
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b3815a7f_f64a_48f6_b0ce_d0032578c699
 :substance_b3815a7f_f64a_48f6_b0ce_d0032578c699 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -5080,7 +5080,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Gold"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b403f5ab_25b5_4721_983d_2792a7624972
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b403f5ab_25b5_4721_983d_2792a7624972
 :substance_b403f5ab_25b5_4721_983d_2792a7624972 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_878a0e2f_12ba_484e_8197_75e57139d207 ,
                                                                 :substance_961f7671_8708_4ce3_9c7d_79444adba9c0 ;
@@ -5094,7 +5094,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Ethanol"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b468a310_e399_40e3_b9b9_6c7d90dbd07b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b468a310_e399_40e3_b9b9_6c7d90dbd07b
 :substance_b468a310_e399_40e3_b9b9_6c7d90dbd07b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4ca80d73_ea14_4a81_9df1_8a16ecbfd041 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q417022"@en ;
@@ -5107,13 +5107,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "RutheniumIVOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b474f792_011e_4c9a_8dee_b99d6459cd66
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b474f792_011e_4c9a_8dee_b99d6459cd66
 :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ;
                                                 skos:prefLabel "TransitionMetalOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b496f6dd_0476_43e7_a1a9_7e025afce627
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b496f6dd_0476_43e7_a1a9_7e025afce627
 :substance_b496f6dd_0476_43e7_a1a9_7e025afce627 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -5126,7 +5126,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Manganese"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b593b5dd_7957_4b85_856a_dd59775210b6
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b593b5dd_7957_4b85_856a_dd59775210b6
 :substance_b593b5dd_7957_4b85_856a_dd59775210b6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407927"@en ;
@@ -5139,7 +5139,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "DimethylSulfoxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b5ad0a60_44cf_40b2_880d_92a195a65859
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b5ad0a60_44cf_40b2_880d_92a195a65859
 :substance_b5ad0a60_44cf_40b2_880d_92a195a65859 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -5152,14 +5152,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Scandium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b5d8ff31_cc34_4f22_bfcc_7ffbe69c0b26
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b5d8ff31_cc34_4f22_bfcc_7ffbe69c0b26
 :substance_b5d8ff31_cc34_4f22_bfcc_7ffbe69c0b26 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 skos:altLabel "Sr(BOB)2"@en ;
                                                 skos:prefLabel "StrontiumBisoxalatoborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b67e85ce_a540_43bd_a3b5_0a5fe341194e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b67e85ce_a540_43bd_a3b5_0a5fe341194e
 :substance_b67e85ce_a540_43bd_a3b5_0a5fe341194e rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -5172,7 +5172,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Vanadium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b6ec6818_6d76_41b7_83d4_92b8e2363b90
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b6ec6818_6d76_41b7_83d4_92b8e2363b90
 :substance_b6ec6818_6d76_41b7_83d4_92b8e2363b90 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q415471"@en ;
@@ -5185,7 +5185,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumNitrate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b6ecabf9_14a4_4808_a139_55329e70ad42
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b6ecabf9_14a4_4808_a139_55329e70ad42
 :substance_b6ecabf9_14a4_4808_a139_55329e70ad42 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q416271"@en ;
@@ -5198,7 +5198,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Dimethoxyethane"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b72166c7_eb2a_44b0_8af4_3a2042148157
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b72166c7_eb2a_44b0_8af4_3a2042148157
 :substance_b72166c7_eb2a_44b0_8af4_3a2042148157 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q412538"@en ;
@@ -5211,7 +5211,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumIodide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b7c3fc7f_a189_46ff_bd3d_21f899507e94
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b7c3fc7f_a189_46ff_bd3d_21f899507e94
 :substance_b7c3fc7f_a189_46ff_bd3d_21f899507e94 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q6731399"@en ;
@@ -5224,7 +5224,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumPhosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b7f0a973_a394_409a_8752_f920b001c2d7
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b7f0a973_a394_409a_8752_f920b001c2d7
 :substance_b7f0a973_a394_409a_8752_f920b001c2d7 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4202651"@en ;
@@ -5236,7 +5236,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIodide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b8b79435_2d26_4784_8c36_385ec8ef9661
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b8b79435_2d26_4784_8c36_385ec8ef9661
 :substance_b8b79435_2d26_4784_8c36_385ec8ef9661 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q3998748"@en ;
@@ -5249,7 +5249,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumTriflate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b8baff0d_7163_4ef1_ac3b_7694b59e500a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b8baff0d_7163_4ef1_ac3b_7694b59e500a
 :substance_b8baff0d_7163_4ef1_ac3b_7694b59e500a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q420616"@en ;
@@ -5263,19 +5263,19 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "DiethylCarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b8c65e71_05de_4f07_acd8_a16938b550fd
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b8c65e71_05de_4f07_acd8_a16938b550fd
 :substance_b8c65e71_05de_4f07_acd8_a16938b550fd rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "NickelOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b978912b_19ef_4d46_8c91_2e3578b12670
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b978912b_19ef_4d46_8c91_2e3578b12670
 :substance_b978912b_19ef_4d46_8c91_2e3578b12670 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ;
                                                 skos:prefLabel "PostTransitionMetalElementalSubstance"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b9d12a93_8bcc_4da1_ab17_3c5bbe25ba5f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b9d12a93_8bcc_4da1_ab17_3c5bbe25ba5f
 :substance_b9d12a93_8bcc_4da1_ab17_3c5bbe25ba5f rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_8e5448fc_1916_4afb_9fd9_2489797f6922 ;
@@ -5289,7 +5289,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelHydroxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_b9d9fc15_544b_4b9f_b39c_250b90c379b7
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_b9d9fc15_544b_4b9f_b39c_250b90c379b7
 :substance_b9d9fc15_544b_4b9f_b39c_250b90c379b7 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q27273582"@en ;
@@ -5300,7 +5300,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "DimethoxyDimethylSilane"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ba4394f5_21c3_4ae1_96a4_3c9e2138b7e0
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ba4394f5_21c3_4ae1_96a4_3c9e2138b7e0
 :substance_ba4394f5_21c3_4ae1_96a4_3c9e2138b7e0 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q416265"@en ;
@@ -5313,7 +5313,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumIodide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_badb80db_ae6e_4048_a720_e26229995443
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_badb80db_ae6e_4048_a720_e26229995443
 :substance_badb80db_ae6e_4048_a720_e26229995443 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q376994"@en ;
@@ -5326,7 +5326,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Pseudocumeme"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_bafc6512_126d_4d9a_9c08_2b210317e77f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_bafc6512_126d_4d9a_9c08_2b210317e77f
 :substance_bafc6512_126d_4d9a_9c08_2b210317e77f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/23515" ;
@@ -5338,7 +5338,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Hexafluoroarsenate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_bb20bdea_343c_4911_8c45_37fc1077d22f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_bb20bdea_343c_4911_8c45_37fc1077d22f
 :substance_bb20bdea_343c_4911_8c45_37fc1077d22f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q15632858"@en ;
@@ -5350,7 +5350,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "EthylMethylCarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_bb42264f_9049_47a5_ac87_a363fa8ae503
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_bb42264f_9049_47a5_ac87_a363fa8ae503
 :substance_bb42264f_9049_47a5_ac87_a363fa8ae503 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/6096284" ;
@@ -5361,7 +5361,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumTetrafluoroborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_bb66572a_387d_4384_92d8_fdf71918dc45
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_bb66572a_387d_4384_92d8_fdf71918dc45
 :substance_bb66572a_387d_4384_92d8_fdf71918dc45 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2823289"@en ;
@@ -5373,7 +5373,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MesoxalicAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_bbfa82dc_68a0_4d0b_a3f0_735cbbc19cf2
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_bbfa82dc_68a0_4d0b_a3f0_735cbbc19cf2
 :substance_bbfa82dc_68a0_4d0b_a3f0_735cbbc19cf2 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -5386,13 +5386,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Iridium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_bc76f17d_931a_4728_9663_9f8ed208d5e4
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_bc76f17d_931a_4728_9663_9f8ed208d5e4
 :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_015116fe_94ca_4be5_9d14_9d9457a47a72 ;
                                                 skos:prefLabel "CobaltSaltCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_bc7f9905_0c1d_4911_9155_d31e96dceb55
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_bc7f9905_0c1d_4911_9155_d31e96dceb55
 :substance_bc7f9905_0c1d_4911_9155_d31e96dceb55 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_cac14194_2d5f_4fe6_b794_a9319f6d76ee ;
@@ -5405,13 +5405,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Radon"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_bc9ba950_96c1_4ac2_a0e2_1c4f7f001b1d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_bc9ba950_96c1_4ac2_a0e2_1c4f7f001b1d
 :substance_bc9ba950_96c1_4ac2_a0e2_1c4f7f001b1d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "LeadOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_bd6a2a7a_d9d6_453e_a1d8_2048e884d36e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_bd6a2a7a_d9d6_453e_a1d8_2048e884d36e
 :substance_bd6a2a7a_d9d6_453e_a1d8_2048e884d36e rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_78400dc0_97b0_4d59_8ea6_30bb703f428c ;
@@ -5425,7 +5425,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Bromine"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_bd75a1b8_f5fe_4676_a42c_6192c3a70b22
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_bd75a1b8_f5fe_4676_a42c_6192c3a70b22
 :substance_bd75a1b8_f5fe_4676_a42c_6192c3a70b22 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421854"@en ;
@@ -5438,7 +5438,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIIAcetate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_bdeefc5a_a32a_4354_a7a3_2a842784a937
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_bdeefc5a_a32a_4354_a7a3_2a842784a937
 :substance_bdeefc5a_a32a_4354_a7a3_2a842784a937 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409393"@en ;
@@ -5451,7 +5451,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIISulfate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_be030e60_3df6_4147_ba07_c99618bed3fb
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_be030e60_3df6_4147_ba07_c99618bed3fb
 :substance_be030e60_3df6_4147_ba07_c99618bed3fb rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204783"@en ;
@@ -5464,7 +5464,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincFluoride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_be34d464_0eb9_4861_8998_5cce0f1e2979
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_be34d464_0eb9_4861_8998_5cce0f1e2979
 :substance_be34d464_0eb9_4861_8998_5cce0f1e2979 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q412874"@en ;
@@ -5477,7 +5477,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumSulfide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_bea2f4f7_04b9_48db_aae3_a04832c0f58d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_bea2f4f7_04b9_48db_aae3_a04832c0f58d
 :substance_bea2f4f7_04b9_48db_aae3_a04832c0f58d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q15634038"@en ;
@@ -5490,7 +5490,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIIPhosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_beb2ddc0_17f9_430d_b271_31fc2d6ca1a1
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_beb2ddc0_17f9_430d_b271_31fc2d6ca1a1
 :substance_beb2ddc0_17f9_430d_b271_31fc2d6ca1a1 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_f5b930f9_2f95_4268_993c_ff6b57ae7691 ;
@@ -5504,13 +5504,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SulfuricAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_bed1a22c_8b61_467a_86a0_d24c7b910653
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_bed1a22c_8b61_467a_86a0_d24c7b910653
 :substance_bed1a22c_8b61_467a_86a0_d24c7b910653 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7beec353_bad9_46fc_a035_a76b131fb32b ;
                                                 skos:prefLabel "StrongBaseCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_bf30b2d9_adc4_424a_83b0_927d33b2cbad
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_bf30b2d9_adc4_424a_83b0_927d33b2cbad
 :substance_bf30b2d9_adc4_424a_83b0_927d33b2cbad rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_6c0cc397_d8c4_4473_a09f_1e5de568e0dd ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q169917"@en ;
@@ -5522,7 +5522,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Graphene"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_bf339a87_3d85_48bf_b10e_dcf482af3b71
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_bf339a87_3d85_48bf_b10e_dcf482af3b71
 :substance_bf339a87_3d85_48bf_b10e_dcf482af3b71 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204714"@en ;
@@ -5535,7 +5535,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincChloride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_bf4787df_bf4f_4ebd_bd0b_17f982591761
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_bf4787df_bf4f_4ebd_bd0b_17f982591761
 :substance_bf4787df_bf4f_4ebd_bd0b_17f982591761 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q528995"@en ;
@@ -5548,7 +5548,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Thiourea"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_bf77edae_ea79_45fb_9ed1_5b8a24665cca
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_bf77edae_ea79_45fb_9ed1_5b8a24665cca
 :substance_bf77edae_ea79_45fb_9ed1_5b8a24665cca rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q15768"@en ;
@@ -5561,7 +5561,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumBromide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_bf83d174_677d_45ec_ab8b_fef7109ad91c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_bf83d174_677d_45ec_ab8b_fef7109ad91c
 :substance_bf83d174_677d_45ec_ab8b_fef7109ad91c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0111fe83_2d6c_4df0_9fd3_500ddda7242c ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/16702109" ;
@@ -5572,7 +5572,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "GalliumIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c0adf859_7694_440e_8c65_cb2b6b67f88b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c0adf859_7694_440e_8c65_cb2b6b67f88b
 :substance_c0adf859_7694_440e_8c65_cb2b6b67f88b rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a4a5b239_d88e_4e03_a763_0bf2a3dd0f47 ;
@@ -5586,14 +5586,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Radium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c0ed3eca_64ef_4e69_a415_3e5f76ca27b6
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c0ed3eca_64ef_4e69_a415_3e5f76ca27b6
 :substance_c0ed3eca_64ef_4e69_a415_3e5f76ca27b6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 skos:altLabel "Mg(BOP)2"@en ;
                                                 skos:prefLabel "MagnesiumBisoxalatophosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c0f3ef19_325e_469d_95d4_2d7568796163
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c0f3ef19_325e_469d_95d4_2d7568796163
 :substance_c0f3ef19_325e_469d_95d4_2d7568796163 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_52da9471_9979_44b0_a415_63c72110fd43 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q196680"@en ;
@@ -5606,7 +5606,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IronIIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c109ca45_08c7_4436_a818_a9c575785e2f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c109ca45_08c7_4436_a818_a9c575785e2f
 :substance_c109ca45_08c7_4436_a818_a9c575785e2f rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_68e4028b_0ec6_46da_8d1c_d00c644e8c82 ;
@@ -5620,13 +5620,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Lithium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c12c3203_9d18_4a69_8a10_25b100ff48c8
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c12c3203_9d18_4a69_8a10_25b100ff48c8
 :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_fc93282d_cb35_4bab_81a8_78689ae59e5f ;
                                                 skos:prefLabel "CalciumSaltCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c1b3e4ab_f4c2_443e_9143_99e7c3654448
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c1b3e4ab_f4c2_443e_9143_99e7c3654448
 :substance_c1b3e4ab_f4c2_443e_9143_99e7c3654448 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4ad18bbe_6478_4009_8f80_b669a6ae3f7a ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4332822"@en ;
@@ -5638,7 +5638,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IridiumIIIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c28a0967_ed23_48cc_a14e_a651d75a19db
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c28a0967_ed23_48cc_a14e_a651d75a19db
 :substance_c28a0967_ed23_48cc_a14e_a651d75a19db rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q81988484"@en ;
@@ -5650,7 +5650,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumNickelOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c3474f9a_87bd_4b73_9398_6e1ccbf133af
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c3474f9a_87bd_4b73_9398_6e1ccbf133af
 :substance_c3474f9a_87bd_4b73_9398_6e1ccbf133af rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q191831"@en ;
@@ -5663,7 +5663,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumSulfate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c38dc7a0_bbeb_43d8_8fdd_15f6f977332a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c38dc7a0_bbeb_43d8_8fdd_15f6f977332a
 :substance_c38dc7a0_bbeb_43d8_8fdd_15f6f977332a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q408920"@en ;
@@ -5676,7 +5676,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumSulfide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c4a7d7bd_497e_457e_b858_ff73254266d0
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c4a7d7bd_497e_457e_b858_ff73254266d0
 :substance_c4a7d7bd_497e_457e_b858_ff73254266d0 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q416254"@en ;
@@ -5690,7 +5690,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "DimethylCarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c4d116ed_258d_482c_8632_5c8229e7b245
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c4d116ed_258d_482c_8632_5c8229e7b245
 :substance_c4d116ed_258d_482c_8632_5c8229e7b245 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q161249"@en ;
@@ -5702,7 +5702,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LacticAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c505a8a2_feb3_4a8e_92fa_e2fee3cd776b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c505a8a2_feb3_4a8e_92fa_e2fee3cd776b
 :substance_c505a8a2_feb3_4a8e_92fa_e2fee3cd776b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/87861747" ;
@@ -5713,7 +5713,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIITriflate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c5582dae_ccff_4fbe_adaa_078091054640
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c5582dae_ccff_4fbe_adaa_078091054640
 :substance_c5582dae_ccff_4fbe_adaa_078091054640 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/160476084" ;
@@ -5722,14 +5722,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumIronPhosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c581b064_f357_4378_96bc_dcb2c72013f8
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c581b064_f357_4378_96bc_dcb2c72013f8
 :substance_c581b064_f357_4378_96bc_dcb2c72013f8 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 skos:altLabel "Mg(BF4)2"@en ;
                                                 skos:prefLabel "MagnesiumTetrafluoroborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c5adcfc9_d0f3_40d5_8aa0_6836d3c3b374
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c5adcfc9_d0f3_40d5_8aa0_6836d3c3b374
 :substance_c5adcfc9_d0f3_40d5_8aa0_6836d3c3b374 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q414659"@en ;
@@ -5742,7 +5742,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIICarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c5cff8c2_581e_4341_a3e6_8ba8c8ce2d2b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c5cff8c2_581e_4341_a3e6_8ba8c8ce2d2b
 :substance_c5cff8c2_581e_4341_a3e6_8ba8c8ce2d2b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7e716191_b301_4d63_bb6b_93323ffe51bf ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q146174"@en ;
@@ -5751,14 +5751,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Polypropylene"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c5e6b38b_af73_4664_911b_4a6ecc8f2e3f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c5e6b38b_af73_4664_911b_4a6ecc8f2e3f
 :substance_c5e6b38b_af73_4664_911b_4a6ecc8f2e3f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 skos:altLabel "Sr(BOP)2"@en ;
                                                 skos:prefLabel "StrontiumBisoxalatophosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c6c667a8_90ab_4b23_8441_5e7d0eb7dc31
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c6c667a8_90ab_4b23_8441_5e7d0eb7dc31
 :substance_c6c667a8_90ab_4b23_8441_5e7d0eb7dc31 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q11129316"@en ;
@@ -5770,13 +5770,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumTetrafluoroborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f
 :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_6c490298_2ce8_41e1_ac37_4b44faff2d44 ;
                                                 skos:prefLabel "PotassiumSaltCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c7282858_dabe_4cbc_96f9_d5d844986e4f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c7282858_dabe_4cbc_96f9_d5d844986e4f
 :substance_c7282858_dabe_4cbc_96f9_d5d844986e4f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421106"@en ;
@@ -5789,7 +5789,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumSulfate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c728b6b9_449a_45ff_b5ae_6b7968708f0d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c728b6b9_449a_45ff_b5ae_6b7968708f0d
 :substance_c728b6b9_449a_45ff_b5ae_6b7968708f0d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4154e6b6_8e3c_4173_91aa_e8ba403bde85 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1311146"@en ;
@@ -5802,7 +5802,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IronDisulfide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c77f3c17_6eec_4875_92fc_50db5212ea86
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c77f3c17_6eec_4875_92fc_50db5212ea86
 :substance_c77f3c17_6eec_4875_92fc_50db5212ea86 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_878a0e2f_12ba_484e_8197_75e57139d207 ,
                                                                 :substance_961f7671_8708_4ce3_9c7d_79444adba9c0 ;
@@ -5816,7 +5816,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NPropanol"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c7a8d82c_de8f_461f_b86d_62e79ff27e6b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c7a8d82c_de8f_461f_b86d_62e79ff27e6b
 :substance_c7a8d82c_de8f_461f_b86d_62e79ff27e6b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c7bab57c_23c4_41d7_b2dc_497683fc82db ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q3488660"@en ;
@@ -5829,7 +5829,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "RhodiumIIIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c7b881c4_6149_488c_bd47_5e8ccfdd071e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c7b881c4_6149_488c_bd47_5e8ccfdd071e
 :substance_c7b881c4_6149_488c_bd47_5e8ccfdd071e rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a4a5b239_d88e_4e03_a763_0bf2a3dd0f47 ;
@@ -5843,13 +5843,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Beryllium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c7bab57c_23c4_41d7_b2dc_497683fc82db
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c7bab57c_23c4_41d7_b2dc_497683fc82db
 :substance_c7bab57c_23c4_41d7_b2dc_497683fc82db rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "RhodiumOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_c9141094_0700_41ec_8373_4fc52b2f1615
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_c9141094_0700_41ec_8373_4fc52b2f1615
 :substance_c9141094_0700_41ec_8373_4fc52b2f1615 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bed1a22c_8b61_467a_86a0_d24c7b910653 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407605"@en ;
@@ -5862,7 +5862,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumHydroxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ca0f0da1_70d2_46ec_a1bb_0f0662ff4191
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ca0f0da1_70d2_46ec_a1bb_0f0662ff4191
 :substance_ca0f0da1_70d2_46ec_a1bb_0f0662ff4191 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2331023"@en ;
@@ -5875,7 +5875,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIISulfate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_cac01669_51a9_410f_9a12_4bb0e19296f6
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_cac01669_51a9_410f_9a12_4bb0e19296f6
 :substance_cac01669_51a9_410f_9a12_4bb0e19296f6 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a9a6507f_9c61_44d3_bd86_f1ebf763e150 ;
@@ -5889,13 +5889,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Boron"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_cac14194_2d5f_4fe6_b794_a9319f6d76ee
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_cac14194_2d5f_4fe6_b794_a9319f6d76ee
 :substance_cac14194_2d5f_4fe6_b794_a9319f6d76ee rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ;
                                                 skos:prefLabel "NobleGasElementalSubstance"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_cb320164_c9d7_48a0_8b54_f22398ce3e20
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_cb320164_c9d7_48a0_8b54_f22398ce3e20
 :substance_cb320164_c9d7_48a0_8b54_f22398ce3e20 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q23767"@en ;
@@ -5908,13 +5908,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumCarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_cb6d2c65_9977_4bb1_987a_5ea828de445f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_cb6d2c65_9977_4bb1_987a_5ea828de445f
 :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_015116fe_94ca_4be5_9d14_9d9457a47a72 ;
                                                 skos:prefLabel "ManganeseSaltCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_cc155ed5_c60c_4d9f_bfad_fbf6b7c77e57
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_cc155ed5_c60c_4d9f_bfad_fbf6b7c77e57
 :substance_cc155ed5_c60c_4d9f_bfad_fbf6b7c77e57 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q11158" ;
@@ -5931,7 +5931,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
  ] .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ccdce7d4_b695_4871_84c2_13679807d077
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ccdce7d4_b695_4871_84c2_13679807d077
 :substance_ccdce7d4_b695_4871_84c2_13679807d077 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_bed1a22c_8b61_467a_86a0_d24c7b910653 ;
@@ -5945,7 +5945,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumHydroxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ccf52cd9_fc33_44c4_903d_e4a2915bd74a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ccf52cd9_fc33_44c4_903d_e4a2915bd74a
 :substance_ccf52cd9_fc33_44c4_903d_e4a2915bd74a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q18234777"@en ;
@@ -5957,7 +5957,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIIChlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_cd17ca33_ae3d_4738_8930_547673bf6c1f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_cd17ca33_ae3d_4738_8930_547673bf6c1f
 :substance_cd17ca33_ae3d_4738_8930_547673bf6c1f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/substance/472206540" ;
@@ -5965,7 +5965,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumNickelCobaltAluminiumOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_cd8581de_2e32_43ee_b0f0_02de1577c69d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_cd8581de_2e32_43ee_b0f0_02de1577c69d
 :substance_cd8581de_2e32_43ee_b0f0_02de1577c69d rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -5978,7 +5978,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Osmium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_cdd18f0c_e7b3_4d09_b3dd_c09fe4b1adba
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_cdd18f0c_e7b3_4d09_b3dd_c09fe4b1adba
 :substance_cdd18f0c_e7b3_4d09_b3dd_c09fe4b1adba rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q31841811"@en ;
@@ -5986,7 +5986,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumCobaltOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_cfc02dad_a994_430b_a2b2_fd275016c485
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_cfc02dad_a994_430b_a2b2_fd275016c485
 :substance_cfc02dad_a994_430b_a2b2_fd275016c485 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411014"@en ;
@@ -5999,7 +5999,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumNitrate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_cfcaa487_a7ee_401b_902a_afc68158a02f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_cfcaa487_a7ee_401b_902a_afc68158a02f
 :substance_cfcaa487_a7ee_401b_902a_afc68158a02f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q184832"@en ;
@@ -6012,7 +6012,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "OxalicAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d071c9d0_1358_4d9f_9690_53b7d69e025c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d071c9d0_1358_4d9f_9690_53b7d69e025c
 :substance_d071c9d0_1358_4d9f_9690_53b7d69e025c rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -6025,7 +6025,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Rhodium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d0d1db46_f674_437f_a322_2913b1eca5de
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d0d1db46_f674_437f_a322_2913b1eca5de
 :substance_d0d1db46_f674_437f_a322_2913b1eca5de rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q191700"@en ;
@@ -6037,14 +6037,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BenzoicAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d0e03160_256a_4cb2_a086_8f65d3abf62e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d0e03160_256a_4cb2_a086_8f65d3abf62e
 :substance_d0e03160_256a_4cb2_a086_8f65d3abf62e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 skos:altLabel "Sr(TFSI)2"@en ;
                                                 skos:prefLabel "StrontiumBistrifluoromethanesulfonylimide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d185fb35_17e0_44df_9a6b_5c93d56b9c99
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d185fb35_17e0_44df_9a6b_5c93d56b9c99
 :substance_d185fb35_17e0_44df_9a6b_5c93d56b9c99 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q422434"@en ;
@@ -6057,7 +6057,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumPerchlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d24edc6f_d03b_48ff_8a47_780ad7c2e2b2
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d24edc6f_d03b_48ff_8a47_780ad7c2e2b2
 :substance_d24edc6f_d03b_48ff_8a47_780ad7c2e2b2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q309038"@en ;
@@ -6070,7 +6070,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumSulfate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d27a5bb0_b35d_4133_8b2c_b32e94c899ec
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d27a5bb0_b35d_4133_8b2c_b32e94c899ec
 :substance_d27a5bb0_b35d_4133_8b2c_b32e94c899ec rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q107184"@en ;
@@ -6083,7 +6083,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIISulfate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d2b624f6_6929_41c3_8510_5cf0a57e2877
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d2b624f6_6929_41c3_8510_5cf0a57e2877
 :substance_d2b624f6_6929_41c3_8510_5cf0a57e2877 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q82863248"@en ;
@@ -6096,14 +6096,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumSulfite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d30fb481_a68d_496f_9be3_0e78aef3ef32
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d30fb481_a68d_496f_9be3_0e78aef3ef32
 :substance_d30fb481_a68d_496f_9be3_0e78aef3ef32 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 skos:altLabel "Ca(TFSI)2"@en ;
                                                 skos:prefLabel "CalciumBistrifluoromethanesulfonylimide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d36fbe2f_6b0a_4178_b6ca_7373bdefcb51
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d36fbe2f_6b0a_4178_b6ca_7373bdefcb51
 :substance_d36fbe2f_6b0a_4178_b6ca_7373bdefcb51 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7e716191_b301_4d63_bb6b_93323ffe51bf ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411030"@en ;
@@ -6116,7 +6116,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CarboxymethylCellulose"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d3739474_ed71_4e61_b9ae_d7dc2c091179
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d3739474_ed71_4e61_b9ae_d7dc2c091179
 :substance_d3739474_ed71_4e61_b9ae_d7dc2c091179 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4119952"@en ;
@@ -6129,7 +6129,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIITriflate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d441cd55_e84c_450f_a91e_9585b3c24527
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d441cd55_e84c_450f_a91e_9585b3c24527
 :substance_d441cd55_e84c_450f_a91e_9585b3c24527 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_8e5448fc_1916_4afb_9fd9_2489797f6922 ;
@@ -6143,7 +6143,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumHydroxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d459562f_94cb_4b2d_902f_788399c64cfc
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d459562f_94cb_4b2d_902f_788399c64cfc
 :substance_d459562f_94cb_4b2d_902f_788399c64cfc rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409224"@en ;
@@ -6156,7 +6156,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumCarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d47303ca_3445_4579_9684_21aa153140df
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d47303ca_3445_4579_9684_21aa153140df
 :substance_d47303ca_3445_4579_9684_21aa153140df rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/74125" ;
@@ -6167,7 +6167,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PentafluorophenylIsocyanate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d4e965c3_80a8_4d13_a7b9_f1402dd3ae67
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d4e965c3_80a8_4d13_a7b9_f1402dd3ae67
 :substance_d4e965c3_80a8_4d13_a7b9_f1402dd3ae67 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_78400dc0_97b0_4d59_8ea6_30bb703f428c ;
@@ -6180,7 +6180,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Selenium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d53259a7_0d9c_48b9_a6c1_4418169df303
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d53259a7_0d9c_48b9_a6c1_4418169df303
 :substance_d53259a7_0d9c_48b9_a6c1_4418169df303 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_6c0cc397_d8c4_4473_a09f_1e5de568e0dd ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q5309"@en ;
@@ -6193,7 +6193,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Graphite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d53de966_29a4_4a1b_b166_a8c7734eeae0
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d53de966_29a4_4a1b_b166_a8c7734eeae0
 :substance_d53de966_29a4_4a1b_b166_a8c7734eeae0 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407446"@en ;
@@ -6206,7 +6206,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumChlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d5bf1391_1bc2_472d_adc8_1b2407d2af70
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d5bf1391_1bc2_472d_adc8_1b2407d2af70
 :substance_d5bf1391_1bc2_472d_adc8_1b2407d2af70 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421538"@en ;
@@ -6219,7 +6219,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumNitrite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d5c2e705_2e15_4c97_9d6a_0c90afa606ec
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d5c2e705_2e15_4c97_9d6a_0c90afa606ec
 :substance_d5c2e705_2e15_4c97_9d6a_0c90afa606ec rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q416688"@en ;
@@ -6232,7 +6232,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIISulfide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d6031563_07c3_4cf7_852e_474dce2acc1c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d6031563_07c3_4cf7_852e_474dce2acc1c
 :substance_d6031563_07c3_4cf7_852e_474dce2acc1c rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a4a5b239_d88e_4e03_a763_0bf2a3dd0f47 ;
@@ -6246,7 +6246,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Strontium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d673ceb2_3045_4e2e_8cad_56f5169b542f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d673ceb2_3045_4e2e_8cad_56f5169b542f
 :substance_d673ceb2_3045_4e2e_8cad_56f5169b542f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_001ca83b_5372_4d77_a836_4d48074b7e63 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Titanium_dioxide"@en ;
@@ -6259,7 +6259,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TitaniumDioxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d6b4453f_6a41_446a_874c_5fcce4948ef2
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d6b4453f_6a41_446a_874c_5fcce4948ef2
 :substance_d6b4453f_6a41_446a_874c_5fcce4948ef2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q208451"@en ;
@@ -6272,7 +6272,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumChloride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d6ed8fcd_4d21_4401_b16c_478985799100
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d6ed8fcd_4d21_4401_b16c_478985799100
 :substance_d6ed8fcd_4d21_4401_b16c_478985799100 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q420370"@en ;
@@ -6285,7 +6285,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIIBromide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d729ecb6_dd34_43fa_a67d_33045483fa7c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d729ecb6_dd34_43fa_a67d_33045483fa7c
 :substance_d729ecb6_dd34_43fa_a67d_33045483fa7c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q7553385"@en ;
@@ -6298,7 +6298,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumTriflate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d72cdf03_965d_4149_865f_d44ed9e5e1b8
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d72cdf03_965d_4149_865f_d44ed9e5e1b8
 :substance_d72cdf03_965d_4149_865f_d44ed9e5e1b8 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q15411014"@en ;
@@ -6310,7 +6310,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "GlycidicAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d7314c57_c073_4a7a_afa3_e81fea4b44a3
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d7314c57_c073_4a7a_afa3_e81fea4b44a3
 :substance_d7314c57_c073_4a7a_afa3_e81fea4b44a3 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_cac14194_2d5f_4fe6_b794_a9319f6d76ee ;
@@ -6323,7 +6323,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Neon"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d7f2ab2a_e3ff_4aea_8cf1_862df545c882
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d7f2ab2a_e3ff_4aea_8cf1_862df545c882
 :substance_d7f2ab2a_e3ff_4aea_8cf1_862df545c882 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421972"@en ;
@@ -6335,7 +6335,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MalonicAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d9a71272_91cb_45d7_8e4b_960ec3c79981
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d9a71272_91cb_45d7_8e4b_960ec3c79981
 :substance_d9a71272_91cb_45d7_8e4b_960ec3c79981 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204679"@en ;
@@ -6348,7 +6348,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincBromide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d9c342d8_497e_4378_96e2_3b9b2c42cf17
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d9c342d8_497e_4378_96e2_3b9b2c42cf17
 :substance_d9c342d8_497e_4378_96e2_3b9b2c42cf17 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204873"@en ;
@@ -6361,13 +6361,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumCarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_d9f73522_049b_4542_909d_d7daefa9613b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_d9f73522_049b_4542_909d_d7daefa9613b
 :substance_d9f73522_049b_4542_909d_d7daefa9613b rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "MercuryOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_da1623c4_3d3b_4c9d_8601_ea055848df39
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_da1623c4_3d3b_4c9d_8601_ea055848df39
 :substance_da1623c4_3d3b_4c9d_8601_ea055848df39 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407270"@en ;
@@ -6380,7 +6380,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumChloride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_da29bb03_cd0d_44b2_9c94_f62ae56f5def
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_da29bb03_cd0d_44b2_9c94_f62ae56f5def
 :substance_da29bb03_cd0d_44b2_9c94_f62ae56f5def rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1223259"@en ;
@@ -6392,7 +6392,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Ethylmonoglyme"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_da48c6df_3730_490e_a970_44ef4a6cbf4e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_da48c6df_3730_490e_a970_44ef4a6cbf4e
 :substance_da48c6df_3730_490e_a970_44ef4a6cbf4e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_63788521_5764_4ee2_8d8a_ce4978682546 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q27272874"@en ;
@@ -6404,13 +6404,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IndiumIIICarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_dae2320d_be18_44ba_90bd_8176decc4b47
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_dae2320d_be18_44ba_90bd_8176decc4b47
 :substance_dae2320d_be18_44ba_90bd_8176decc4b47 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f07ae87e_b56e_4835_8a28_04c6c7dfbaa2 ;
                                                 skos:prefLabel "Cation"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_db74b6b7_09fc_40db_a7d5_6eb86b69192a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_db74b6b7_09fc_40db_a7d5_6eb86b69192a
 :substance_db74b6b7_09fc_40db_a7d5_6eb86b69192a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_155e894b_66de_4cda_9dbe_adbeca7d8102 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q129163"@en ;
@@ -6423,7 +6423,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TinIVOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_db926a48_0b3c_4f6d_89f5_a333af85ecbd
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_db926a48_0b3c_4f6d_89f5_a333af85ecbd
 :substance_db926a48_0b3c_4f6d_89f5_a333af85ecbd rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q3877375"@en ;
@@ -6435,7 +6435,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincNitrite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_dbbedf09_18c4_416a_99c2_f381a74d2551
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_dbbedf09_18c4_416a_99c2_f381a74d2551
 :substance_dbbedf09_18c4_416a_99c2_f381a74d2551 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/3082513" ;
@@ -6446,7 +6446,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TetrapotassiumHeptaiodobismuthate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_dc592618_13ec_498a_834b_2188ecb9535d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_dc592618_13ec_498a_834b_2188ecb9535d
 :substance_dc592618_13ec_498a_834b_2188ecb9535d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q408464"@en ;
@@ -6459,7 +6459,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumSulfide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_dc5fb846_1824_40f8_9834_81f118aa1c2d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_dc5fb846_1824_40f8_9834_81f118aa1c2d
 :substance_dc5fb846_1824_40f8_9834_81f118aa1c2d rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -6472,13 +6472,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Mercury"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_dc68514f_b592_4e1b_a00f_fbb29f2fafbd
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_dc68514f_b592_4e1b_a00f_fbb29f2fafbd
 :substance_dc68514f_b592_4e1b_a00f_fbb29f2fafbd rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7e716191_b301_4d63_bb6b_93323ffe51bf ;
                                                 skos:prefLabel "IonomerCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_dc9ae81a_b5ac_45b6_8b66_9ee6b821d475
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_dc9ae81a_b5ac_45b6_8b66_9ee6b821d475
 :substance_dc9ae81a_b5ac_45b6_8b66_9ee6b821d475 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7e716191_b301_4d63_bb6b_93323ffe51bf ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q410083"@en ;
@@ -6488,7 +6488,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PolyethyleneGlycol"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_dcb0d128_c3db_4c91_84ba_af9df1688766
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_dcb0d128_c3db_4c91_84ba_af9df1688766
 :substance_dcb0d128_c3db_4c91_84ba_af9df1688766 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc9ba950_96c1_4ac2_a0e2_1c4f7f001b1d ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q419205"@en ;
@@ -6501,7 +6501,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadII_IVOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_dcdbdbed_2e20_40d1_a7a5_5761de7f0618
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_dcdbdbed_2e20_40d1_a7a5_5761de7f0618
 :substance_dcdbdbed_2e20_40d1_a7a5_5761de7f0618 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a4d05f1_dd15_465b_8b44_704238e20813 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407674"@en ;
@@ -6514,13 +6514,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseDioxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_dce90b66_3414_4f5d_b818_4a0e4339e949
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_dce90b66_3414_4f5d_b818_4a0e4339e949
 :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_015116fe_94ca_4be5_9d14_9d9457a47a72 ;
                                                 skos:prefLabel "NickelSaltCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_dd746094_1893_4b77_9c07_13b3bd94a742
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_dd746094_1893_4b77_9c07_13b3bd94a742
 :substance_dd746094_1893_4b77_9c07_13b3bd94a742 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2786508"@en ;
@@ -6534,21 +6534,21 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Hexafluorophosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_dd8823eb_ea6f_49f2_a4f9_d21828cb8b8e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_dd8823eb_ea6f_49f2_a4f9_d21828cb8b8e
 :substance_dd8823eb_ea6f_49f2_a4f9_d21828cb8b8e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 skos:altLabel "Ca(TFOB)2"@en ;
                                                 skos:prefLabel "CalciumTrifluoromethanesulfonyloxalatoborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_de038959_9251_48d1_a141_3684f14d957f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_de038959_9251_48d1_a141_3684f14d957f
 :substance_de038959_9251_48d1_a141_3684f14d957f rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ;
                                                 emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "substance that can act as an acid or a base"@en ;
                                                 skos:prefLabel "AmphotericCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_de52b69b_3c86_4f1c_a467_7a1fa411bc36
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_de52b69b_3c86_4f1c_a467_7a1fa411bc36
 :substance_de52b69b_3c86_4f1c_a467_7a1fa411bc36 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q417806"@en ;
@@ -6561,7 +6561,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIISulfide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_dedc4519_9651_415e_95e8_1ed03b195244
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_dedc4519_9651_415e_95e8_1ed03b195244
 :substance_dedc4519_9651_415e_95e8_1ed03b195244 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q412015"@en ;
@@ -6574,7 +6574,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumPerchlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_df038b95_6c39_4fce_8c16_237057a08c0b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_df038b95_6c39_4fce_8c16_237057a08c0b
 :substance_df038b95_6c39_4fce_8c16_237057a08c0b rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -6587,7 +6587,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Chromium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_df24fad8_7ef0_4330_a3f2_c4d65d9a3be8
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_df24fad8_7ef0_4330_a3f2_c4d65d9a3be8
 :substance_df24fad8_7ef0_4330_a3f2_c4d65d9a3be8 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72488070"@en ;
@@ -6599,7 +6599,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumTriflate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_df5d45a8_ce23_46f7_92b2_84dd28942b0d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_df5d45a8_ce23_46f7_92b2_84dd28942b0d
 :substance_df5d45a8_ce23_46f7_92b2_84dd28942b0d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q18212211"@en ;
@@ -6612,7 +6612,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIIPhosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_df72af75_cc1c_4286_aeb8_66de90ef276d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_df72af75_cc1c_4286_aeb8_66de90ef276d
 :substance_df72af75_cc1c_4286_aeb8_66de90ef276d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_5a5e8609_83bf_46d1_a1b0_eaafa27aaed4 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/5257893" ;
@@ -6623,7 +6623,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Bis(fluorosulfonyl)amide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_dfa3d84e_279c_47d0_ad87_5a30b1a325ce
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_dfa3d84e_279c_47d0_ad87_5a30b1a325ce
 :substance_dfa3d84e_279c_47d0_ad87_5a30b1a325ce rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/170058" ;
@@ -6635,7 +6635,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIITetrafluoroborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_e04eb6c9_7de2_46d4_bab2_25ff819d74ab
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_e04eb6c9_7de2_46d4_bab2_25ff819d74ab
 :substance_e04eb6c9_7de2_46d4_bab2_25ff819d74ab rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7e716191_b301_4d63_bb6b_93323ffe51bf ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q143252"@en ;
@@ -6645,7 +6645,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Polyterafluoroethylene"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_e0b08aed_a2c6_4168_84fc_940e4d0bdd97
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_e0b08aed_a2c6_4168_84fc_940e4d0bdd97
 :substance_e0b08aed_a2c6_4168_84fc_940e4d0bdd97 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q16685924"@en ;
@@ -6658,7 +6658,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIIPerchlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_e128782f_8c69_43b2_9c3c_9efb31e8a6b5
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_e128782f_8c69_43b2_9c3c_9efb31e8a6b5
 :substance_e128782f_8c69_43b2_9c3c_9efb31e8a6b5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a06bf8d8_24d5_4b29_a633_e5c00b1bd746 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4337166"@en ;
@@ -6670,7 +6670,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumPhosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_e1569fd3_34ac_440c_845c_f7c85f59c88d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_e1569fd3_34ac_440c_845c_f7c85f59c88d
 :substance_e1569fd3_34ac_440c_845c_f7c85f59c88d rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4321627"@en ;
@@ -6682,7 +6682,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumNitrite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_e1bfc0f5_7192_49f2_9ce1_1be2467e0b7a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_e1bfc0f5_7192_49f2_9ce1_1be2467e0b7a
 :substance_e1bfc0f5_7192_49f2_9ce1_1be2467e0b7a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q204863"@en ;
@@ -6695,7 +6695,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincNitrate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_e1d2936e_8382_463e_bd83_f7bac40c355b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_e1d2936e_8382_463e_bd83_f7bac40c355b
 :substance_e1d2936e_8382_463e_bd83_f7bac40c355b rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a9a6507f_9c61_44d3_bd86_f1ebf763e150 ;
@@ -6709,7 +6709,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Antimony"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_e1de5285_dbc5_4845_9f8d_9821708681ca
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_e1de5285_dbc5_4845_9f8d_9821708681ca
 :substance_e1de5285_dbc5_4845_9f8d_9821708681ca rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407666"@en ;
@@ -6722,7 +6722,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumNitrate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_e1e6ff98_0725_4d27_ab21_2ca5a95371f0
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_e1e6ff98_0725_4d27_ab21_2ca5a95371f0
 :substance_e1e6ff98_0725_4d27_ab21_2ca5a95371f0 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -6735,7 +6735,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Silver"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_e24e19b5_57b2_44ab_8ef8_c5ce6c08a16c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_e24e19b5_57b2_44ab_8ef8_c5ce6c08a16c
 :substance_e24e19b5_57b2_44ab_8ef8_c5ce6c08a16c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q79566"@en ;
@@ -6748,7 +6748,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumIodide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_e2764cfb_4fa6_4fe9_85e0_1dfe69a37ff1
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_e2764cfb_4fa6_4fe9_85e0_1dfe69a37ff1
 :substance_e2764cfb_4fa6_4fe9_85e0_1dfe69a37ff1 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_aa92d6c6_2c46_4e7d_9b2c_c95b849041d4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q413953"@en ;
@@ -6761,7 +6761,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AmmoniumIodide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_e2c251a7_27b0_4345_a986_eb6bb8234c74
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_e2c251a7_27b0_4345_a986_eb6bb8234c74
 :substance_e2c251a7_27b0_4345_a986_eb6bb8234c74 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_a639df56_1fb2_47f3_8069_c929b5a84b86 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421440"@en ;
@@ -6774,7 +6774,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "VanadiumIVOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_e3a3dc4f_b910_49e3_b66d_c25ce4889d68
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_e3a3dc4f_b910_49e3_b66d_c25ce4889d68
 :substance_e3a3dc4f_b910_49e3_b66d_c25ce4889d68 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q407849"@en ;
@@ -6787,7 +6787,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIIChloride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_e4512250_04d1_4ad3_9c55_71e7f7db1b98
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_e4512250_04d1_4ad3_9c55_71e7f7db1b98
 :substance_e4512250_04d1_4ad3_9c55_71e7f7db1b98 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q15779"@en ;
@@ -6801,7 +6801,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Toluene"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_e54b6547_e915_4c10_9864_30e6a7b456d7
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_e54b6547_e915_4c10_9864_30e6a7b456d7
 :substance_e54b6547_e915_4c10_9864_30e6a7b456d7 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_88748886_9b7c_4df0_91eb_fe91ecc1b9cd ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2366389"@en ;
@@ -6813,7 +6813,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ChromiumIVOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_e76e313b_6052_4ccf_ad80_8f88815c38da
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_e76e313b_6052_4ccf_ad80_8f88815c38da
 :substance_e76e313b_6052_4ccf_ad80_8f88815c38da rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bed1a22c_8b61_467a_86a0_d24c7b910653 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q132428"@en ;
@@ -6826,7 +6826,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "StrontiumHydroxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_e7a4f9ca_e221_4080_8281_304c3a8290f9
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_e7a4f9ca_e221_4080_8281_304c3a8290f9
 :substance_e7a4f9ca_e221_4080_8281_304c3a8290f9 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421857"@en ;
@@ -6839,7 +6839,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumSulfate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_e7be17c8_49e3_43d9_8859_82e39c5ca594
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_e7be17c8_49e3_43d9_8859_82e39c5ca594
 :substance_e7be17c8_49e3_43d9_8859_82e39c5ca594 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q425190"@en ;
@@ -6852,7 +6852,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumTetrafluoroborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_e884ea99_9b69_4b8e_b932_9c47e1c8ce0c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_e884ea99_9b69_4b8e_b932_9c47e1c8ce0c
 :substance_e884ea99_9b69_4b8e_b932_9c47e1c8ce0c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_584bfc73_2715_417f_973c_552ae58529f5 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/substance/385878341" ;
@@ -6860,7 +6860,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "SodiumBisoxalatoborate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_e8fafdc8_6cd3_4dd0_9630_10ca8e3f1827
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_e8fafdc8_6cd3_4dd0_9630_10ca8e3f1827
 :substance_e8fafdc8_6cd3_4dd0_9630_10ca8e3f1827 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q29565403"@en ;
@@ -6872,7 +6872,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumManganeseOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_e9010b6e_e43b_4454_8231_e67ab1a81a18
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_e9010b6e_e43b_4454_8231_e67ab1a81a18
 :substance_e9010b6e_e43b_4454_8231_e67ab1a81a18 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421443"@en ;
@@ -6885,7 +6885,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIIIodide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ea0471d2_cfe0_4b64_9b0d_118254ed3dcc
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ea0471d2_cfe0_4b64_9b0d_118254ed3dcc
 :substance_ea0471d2_cfe0_4b64_9b0d_118254ed3dcc rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_52da9471_9979_44b0_a415_63c72110fd43 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411235"@en ;
@@ -6898,7 +6898,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IronII_IIIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ea68e1a4_6be8_4686_8701_ba88b40d00b7
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ea68e1a4_6be8_4686_8701_ba88b40d00b7
 :substance_ea68e1a4_6be8_4686_8701_ba88b40d00b7 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -6912,7 +6912,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "DimethylSulfoxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ead9b571_f6ec_46da_955c_7049ecee9366
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ead9b571_f6ec_46da_955c_7049ecee9366
 :substance_ead9b571_f6ec_46da_955c_7049ecee9366 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q416502"@en ;
@@ -6924,7 +6924,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumChlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_eada6f39_231c_45be_ae3e_fd9a67fe0003
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_eada6f39_231c_45be_ae3e_fd9a67fe0003
 :substance_eada6f39_231c_45be_ae3e_fd9a67fe0003 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q421490"@en ;
@@ -6937,7 +6937,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIINitrate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ec7bf3bb_30b3_4f2c_a12d_9f9f9006a955
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ec7bf3bb_30b3_4f2c_a12d_9f9f9006a955
 :substance_ec7bf3bb_30b3_4f2c_a12d_9f9f9006a955 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b07a5287_67d1_4f4f_9640_e0146f713a6c ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q8072312"@en ;
@@ -6950,7 +6950,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ZincTriflate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ecc8bfbf_0a0c_42f4_8296_8ab1278c5e69
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ecc8bfbf_0a0c_42f4_8296_8ab1278c5e69
 :substance_ecc8bfbf_0a0c_42f4_8296_8ab1278c5e69 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q422426"@en ;
@@ -6963,7 +6963,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumFluoride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_eccb603e_76be_435e_902f_7ebd9f26690b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_eccb603e_76be_435e_902f_7ebd9f26690b
 :substance_eccb603e_76be_435e_902f_7ebd9f26690b rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q21099559"@en ;
@@ -6975,7 +6975,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TrimethoxyMethylSilane"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ecd84623_43e2_457e_8988_1bfc9d1fb818
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ecd84623_43e2_457e_8988_1bfc9d1fb818
 :substance_ecd84623_43e2_457e_8988_1bfc9d1fb818 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f5b930f9_2f95_4268_993c_ff6b57ae7691 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q193956"@en ;
@@ -6988,7 +6988,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PerchloricAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ececb906_d081_470b_aa5c_5ea526b0baf8
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ececb906_d081_470b_aa5c_5ea526b0baf8
 :substance_ececb906_d081_470b_aa5c_5ea526b0baf8 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q5138693"@en ;
@@ -7001,7 +7001,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIIChlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ed314de3_c1d7_4901_9fd7_539c6e3de550
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ed314de3_c1d7_4901_9fd7_539c6e3de550
 :substance_ed314de3_c1d7_4901_9fd7_539c6e3de550 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -7014,7 +7014,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Tantalum"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ed8ce122_1ad7_4760_b32b_96610351ef26
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ed8ce122_1ad7_4760_b32b_96610351ef26
 :substance_ed8ce122_1ad7_4760_b32b_96610351ef26 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_2e4767fb_2c1b_43e5_9716_acd3f34b4301 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1676613"@en ;
@@ -7026,7 +7026,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PlatinumOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_edae7b22_461b_432b_b737_3c93feb69b0e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_edae7b22_461b_432b_b737_3c93feb69b0e
 :substance_edae7b22_461b_432b_b737_3c93feb69b0e rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q12370" ;
@@ -7043,7 +7043,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
  ] .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_edef7f16_a517_4577_91b1_a90099869f1b
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_edef7f16_a517_4577_91b1_a90099869f1b
 :substance_edef7f16_a517_4577_91b1_a90099869f1b rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72516362"@en ;
@@ -7055,7 +7055,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "VinylEthyleneCarbonate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ee2e195f_7b51_4444_a472_f76ea9bb5943
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ee2e195f_7b51_4444_a472_f76ea9bb5943
 :substance_ee2e195f_7b51_4444_a472_f76ea9bb5943 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2988108"@en ;
@@ -7068,7 +7068,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "OXylene"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f028e380_2abf_49b8_8e65_9ae788791f3c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f028e380_2abf_49b8_8e65_9ae788791f3c
 :substance_f028e380_2abf_49b8_8e65_9ae788791f3c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_094f08bc_90ea_4118_b136_47e61e495ab5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q4498184"@en ;
@@ -7081,13 +7081,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CopperIIChlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f07ae87e_b56e_4835_8a28_04c6c7dfbaa2
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f07ae87e_b56e_4835_8a28_04c6c7dfbaa2
 :substance_f07ae87e_b56e_4835_8a28_04c6c7dfbaa2 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_21205421_5783_4d3e_81e5_10c5d894a88a ;
                                                 skos:prefLabel "Ion"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f12d9fa2_a9a8_44e9_8f24_ceb9e74b0731
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f12d9fa2_a9a8_44e9_8f24_ceb9e74b0731
 :substance_f12d9fa2_a9a8_44e9_8f24_ceb9e74b0731 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72487579"@en ;
@@ -7099,7 +7099,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumBisfluorosulfonylimide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f1e2238d_f5eb_45b0_9209_f493f821fffc
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f1e2238d_f5eb_45b0_9209_f493f821fffc
 :substance_f1e2238d_f5eb_45b0_9209_f493f821fffc rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409184"@en ;
@@ -7112,7 +7112,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Ethylbenzene"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f1e874cf_3e5e_46e3_9bb9_0befc3f7361a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f1e874cf_3e5e_46e3_9bb9_0befc3f7361a
 :substance_f1e874cf_3e5e_46e3_9bb9_0befc3f7361a rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -7126,7 +7126,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Pyridine"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f1f123bb_59a4_429f_994b_c39415e4c444
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f1f123bb_59a4_429f_994b_c39415e4c444
 :substance_f1f123bb_59a4_429f_994b_c39415e4c444 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409199"@en ;
@@ -7139,13 +7139,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumAcetate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f24cfd50_5d01_4e02_88b5_44a609cfa432
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f24cfd50_5d01_4e02_88b5_44a609cfa432
 :substance_f24cfd50_5d01_4e02_88b5_44a609cfa432 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "SilverOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f2dad0d0_8392_490d_932c_d920f8ff3d64
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f2dad0d0_8392_490d_932c_d920f8ff3d64
 :substance_f2dad0d0_8392_490d_932c_d920f8ff3d64 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2749498"@en ;
@@ -7158,7 +7158,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumNitrite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f2e48e9e_f774_4f42_939f_1fe522efb7c8
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f2e48e9e_f774_4f42_939f_1fe522efb7c8
 :substance_f2e48e9e_f774_4f42_939f_1fe522efb7c8 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7e716191_b301_4d63_bb6b_93323ffe51bf ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q146393"@en ;
@@ -7171,13 +7171,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PolyvinylideneFluoride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6
 :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_8c40be1f_0931_4db9_832f_cb63556f6a5a ;
                                                 skos:prefLabel "AluminiumSaltCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f3e7979a_e3ef_450a_8762_7d8778afe478
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f3e7979a_e3ef_450a_8762_7d8778afe478
 :substance_f3e7979a_e3ef_450a_8762_7d8778afe478 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q120861607"@en ;
@@ -7189,7 +7189,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumNickelManganeseOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f44338b9_7672_4e53_b002_3d980911c349
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f44338b9_7672_4e53_b002_3d980911c349
 :substance_f44338b9_7672_4e53_b002_3d980911c349 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q3234708"@en ;
@@ -7202,7 +7202,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MXylene"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f4dffee2_c642_4114_a748_5e93b3908380
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f4dffee2_c642_4114_a748_5e93b3908380
 :substance_f4dffee2_c642_4114_a748_5e93b3908380 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_bc76f17d_931a_4728_9663_9f8ed208d5e4 ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/15975531" ;
@@ -7213,7 +7213,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CobaltIIBistrifluoromethanesulfonylimide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f4eacd3e_ec96_4448_a090_2f7f18ddda0e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f4eacd3e_ec96_4448_a090_2f7f18ddda0e
 :substance_f4eacd3e_ec96_4448_a090_2f7f18ddda0e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q883666"@en ;
@@ -7226,7 +7226,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIIPhosphate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f57d5d5e_15a4_40de_a8d1_c3504f3c8827
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f57d5d5e_15a4_40de_a8d1_c3504f3c8827
 :substance_f57d5d5e_15a4_40de_a8d1_c3504f3c8827 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2453066"@en ;
@@ -7241,13 +7241,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Triglyme"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f5b930f9_2f95_4268_993c_ff6b57ae7691
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f5b930f9_2f95_4268_993c_ff6b57ae7691
 :substance_f5b930f9_2f95_4268_993c_ff6b57ae7691 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cc155ed5_c60c_4d9f_bfad_fbf6b7c77e57 ;
                                                 skos:prefLabel "StrongAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f6460d8d_5d5e_452d_8853_bdec3796a90e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f6460d8d_5d5e_452d_8853_bdec3796a90e
 :substance_f6460d8d_5d5e_452d_8853_bdec3796a90e rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72515436"@en ;
@@ -7259,7 +7259,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "TFP"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f6eb3754_2ccb_406d_b407_c989a7e1b4f9
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f6eb3754_2ccb_406d_b407_c989a7e1b4f9
 :substance_f6eb3754_2ccb_406d_b407_c989a7e1b4f9 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q27261538"@en ;
@@ -7271,7 +7271,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "DipropylSulfone"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f70feadf_0251_4a46_8716_ee6acb435455
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f70feadf_0251_4a46_8716_ee6acb435455
 :substance_f70feadf_0251_4a46_8716_ee6acb435455 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q48318"@en ;
@@ -7284,7 +7284,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Urea"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f7525766_90cf_43e9_8932_7cb3b14f676f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f7525766_90cf_43e9_8932_7cb3b14f676f
 :substance_f7525766_90cf_43e9_8932_7cb3b14f676f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4ad18bbe_6478_4009_8f80_b669a6ae3f7a ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q418812"@en ;
@@ -7297,7 +7297,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "IridiumDioxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f7a11bfc_4cb1_45a7_8248_8e2d534884d3
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f7a11bfc_4cb1_45a7_8248_8e2d534884d3
 :substance_f7a11bfc_4cb1_45a7_8248_8e2d534884d3 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2468"@en ;
@@ -7310,13 +7310,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "HydrogenFluoride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f7d13311_6dd1_422c_b32b_b55fd9e77145
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f7d13311_6dd1_422c_b32b_b55fd9e77145
 :substance_f7d13311_6dd1_422c_b32b_b55fd9e77145 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b474f792_011e_4c9a_8dee_b99d6459cd66 ;
                                                 skos:prefLabel "CopperOxideCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f8954854_f303_4a2e_9e81_ff1a20623c96
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f8954854_f303_4a2e_9e81_ff1a20623c96
 :substance_f8954854_f303_4a2e_9e81_ff1a20623c96 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q2091170"@en ;
@@ -7329,7 +7329,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumNitrite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f8d50782_11fa_4188_ba55_d043d2eb597d
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f8d50782_11fa_4188_ba55_d043d2eb597d
 :substance_f8d50782_11fa_4188_ba55_d043d2eb597d rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -7342,7 +7342,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Titanium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f8ed464a_16e3_491e_b366_6c933e689fa5
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f8ed464a_16e3_491e_b366_6c933e689fa5
 :substance_f8ed464a_16e3_491e_b366_6c933e689fa5 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q411436"@en ;
@@ -7355,7 +7355,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIISulfide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f92b3948_72a5_4662_acf7_5d8dd64e85de
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f92b3948_72a5_4662_acf7_5d8dd64e85de
 :substance_f92b3948_72a5_4662_acf7_5d8dd64e85de rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -7368,7 +7368,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Nickel"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f96ceacb_2808_4c4d_925c_d28086c8a2e1
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f96ceacb_2808_4c4d_925c_d28086c8a2e1
 :substance_f96ceacb_2808_4c4d_925c_d28086c8a2e1 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_2fc3e95b_6f48_47ea_a366_bcc26336239a ;
@@ -7381,7 +7381,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Palladium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_f9b2b3e1_058c_46c5_9004_32b23fd728be
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_f9b2b3e1_058c_46c5_9004_32b23fd728be
 :substance_f9b2b3e1_058c_46c5_9004_32b23fd728be rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c6e80ad7_1aef_4c6d_a51a_4aec8855a68f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q409179"@en ;
@@ -7394,7 +7394,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PotassiumNitrite"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_fa20cd88_2a7d_4820_9f22_d55e1f592b5c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_fa20cd88_2a7d_4820_9f22_d55e1f592b5c
 :substance_fa20cd88_2a7d_4820_9f22_d55e1f592b5c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_cb6d2c65_9977_4bb1_987a_5ea828de445f ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q414680"@en ;
@@ -7407,7 +7407,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ManganeseIIFluoride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_fabdb93c_dc23_40a9_ae83_8981d2bea07e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_fabdb93c_dc23_40a9_ae83_8981d2bea07e
 :substance_fabdb93c_dc23_40a9_ae83_8981d2bea07e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f5b930f9_2f95_4268_993c_ff6b57ae7691 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q83320"@en ;
@@ -7420,7 +7420,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NitricAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_fadf36f3_166e_4a2d_a933_7072e6bc578c
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_fadf36f3_166e_4a2d_a933_7072e6bc578c
 :substance_fadf36f3_166e_4a2d_a933_7072e6bc578c rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0001e895_e74b_438f_b47f_b52f33d68331 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q420413"@en ;
@@ -7433,7 +7433,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MagnesiumBromide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_fbefcf90_c797_4d2f_a072_3d603e42ca9a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_fbefcf90_c797_4d2f_a072_3d603e42ca9a
 :substance_fbefcf90_c797_4d2f_a072_3d603e42ca9a rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_4e659c69_ca2d_4569_8a96_f99857a1fa32 ,
                                                                 :substance_15d08ff9_7685_4020_8481_d9c9b0052176 ;
@@ -7447,7 +7447,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "ThionylChloride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_fc4220a5_3f91_4a60_83c3_4c1be988c2f1
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_fc4220a5_3f91_4a60_83c3_4c1be988c2f1
 :substance_fc4220a5_3f91_4a60_83c3_4c1be988c2f1 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_a4a5b239_d88e_4e03_a763_0bf2a3dd0f47 ;
@@ -7461,7 +7461,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Barium"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_fc7a3d86_8399_4afa_9d12_f5265ec6ec0e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_fc7a3d86_8399_4afa_9d12_f5265ec6ec0e
 :substance_fc7a3d86_8399_4afa_9d12_f5265ec6ec0e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q425231"@en ;
@@ -7474,13 +7474,13 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIIBromide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_fc93282d_cb35_4bab_81a8_78689ae59e5f
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_fc93282d_cb35_4bab_81a8_78689ae59e5f
 :substance_fc93282d_cb35_4bab_81a8_78689ae59e5f rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_edae7b22_461b_432b_b737_3c93feb69b0e ;
                                                 skos:prefLabel "AlkalineEarthMetalSaltCompound"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_fcc8de17_cb4d_409e_93ef_4970df535743
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_fcc8de17_cb4d_409e_93ef_4970df535743
 :substance_fcc8de17_cb4d_409e_93ef_4970df535743 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q72444806"@en ;
@@ -7492,7 +7492,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumTriflate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_fd189d24_5434_4f93_b5a9_4796e67d88f1
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_fd189d24_5434_4f93_b5a9_4796e67d88f1
 :substance_fd189d24_5434_4f93_b5a9_4796e67d88f1 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q906306"@en ;
@@ -7505,7 +7505,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "CalciumPerchlorate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_fd587814_4556_4909_8690_9d539d612e2a
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_fd587814_4556_4909_8690_9d539d612e2a
 :substance_fd587814_4556_4909_8690_9d539d612e2a rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_d9f73522_049b_4542_909d_d7daefa9613b ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q174727"@en ;
@@ -7518,7 +7518,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "MercuryIIOxide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_fdc7f434_0f3e_423d_9689_d1be939b5537
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_fdc7f434_0f3e_423d_9689_d1be939b5537
 :substance_fdc7f434_0f3e_423d_9689_d1be939b5537 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7e716191_b301_4d63_bb6b_93323ffe51bf ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q145421"@en ;
@@ -7531,7 +7531,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "Polyacrylonitrile"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_fdfcbe9c_164d_4e11_b547_519a1abed8d0
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_fdfcbe9c_164d_4e11_b547_519a1abed8d0
 :substance_fdfcbe9c_164d_4e11_b547_519a1abed8d0 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_704630b8_fee3_49b9_baca_40e2dd276370 ,
                                                                 :substance_7fd3843d_f0b7_4490_bcf3_519fb9e2b150 ;
@@ -7545,14 +7545,14 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "EthylAcetate"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_fe5452de_6d49_4f60_9a15_a022bb5219a2
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_fe5452de_6d49_4f60_9a15_a022bb5219a2
 :substance_fe5452de_6d49_4f60_9a15_a022bb5219a2 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_c12c3203_9d18_4a69_8a10_25b100ff48c8 ;
                                                 skos:altLabel "Ca(FSI)2"@en ;
                                                 skos:prefLabel "CalciumBisfluorosulfonylimide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_feb95008_db3a_4506_b7ff_6263befa0d64
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_feb95008_db3a_4506_b7ff_6263befa0d64
 :substance_feb95008_db3a_4506_b7ff_6263befa0d64 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_b325bdd7_0adf_4522_a4ef_20cd6929e094 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q213580"@en ;
@@ -7564,7 +7564,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "PyruvicAcid"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_fec97ca4_73a1_4b8f_b7ae_eddc88498829
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_fec97ca4_73a1_4b8f_b7ae_eddc88498829
 :substance_fec97ca4_73a1_4b8f_b7ae_eddc88498829 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0331ffd2_7cb2_40d3_80ce_8b4ab7b3adc5 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q408805"@en ;
@@ -7577,7 +7577,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LeadIIIodide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_fed5b5ee_de69_405d_9ce1_d6aaf89017db
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_fed5b5ee_de69_405d_9ce1_d6aaf89017db
 :substance_fed5b5ee_de69_405d_9ce1_d6aaf89017db rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_f313522b_e2c4_4251_ba7f_d6b9dc7db1d6 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q259311"@en ;
@@ -7590,7 +7590,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "AluminiumBromide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ff0f6cb9_d9e7_4a9e_848f_02200eed0cf7
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ff0f6cb9_d9e7_4a9e_848f_02200eed0cf7
 :substance_ff0f6cb9_d9e7_4a9e_848f_02200eed0cf7 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_7dd5ebb3_1084_485a_9fbf_05954cd2da84 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q414613"@en ;
@@ -7603,7 +7603,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "BariumBromide"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ff193c19_3ddf_4c61_96f1_322254c3980e
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ff193c19_3ddf_4c61_96f1_322254c3980e
 :substance_ff193c19_3ddf_4c61_96f1_322254c3980e rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_4744a12c_ca28_46b4_9e59_43c1cc15b536 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q422930"@en ;
@@ -7616,7 +7616,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "LithiumChloride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ff2979a3_06b8_416c_bc49_208d96f25fa4
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ff2979a3_06b8_416c_bc49_208d96f25fa4
 :substance_ff2979a3_06b8_416c_bc49_208d96f25fa4 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_dce90b66_3414_4f5d_b818_4a0e4339e949 ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q416623"@en ;
@@ -7629,7 +7629,7 @@ dcterms:source rdf:type owl:AnnotationProperty .
                                                 skos:prefLabel "NickelIIFluoride"@en .
 
 
-###  https://w3id.org/emmo/chemicalsubstance#substance_ff5b9c8c_3fb0_4575_9ab8_23ebd9116294
+###  https://w3id.org/emmo/domain/chemicalsubstance#substance_ff5b9c8c_3fb0_4575_9ab8_23ebd9116294
 :substance_ff5b9c8c_3fb0_4575_9ab8_23ebd9116294 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_436b11bd_1756_4821_9f14_c9ed6b67552e ,
                                                                 :substance_b978912b_19ef_4d46_8c91_2e3578b12670 ;


### PR DESCRIPTION
This pull request refactors the ontology term IRIs to use the new w3id.org namespace from EMMO and includes a pre-inferred version. 