### PR TITLE
EMMO imports and redefinition

### DIFF
--- a/chemical-substance.ttl
+++ b/chemical-substance.ttl
@@ -12,11 +12,17 @@
 @prefix schema: <https://schema.org/> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix annotations: <https://w3id.org/emmo/top/annotations#> .
-@base <https://w3id.org/emmo/domain/chemical-substance> .
+@base <https://w3id.org/emmo/domain/chemical-substance#> .
 
 <https://w3id.org/emmo/domain/chemical-substance> rdf:type owl:Ontology ;
                                                    owl:versionIRI <https://w3id.org/emmo/domain/chemical-substance/0.11.0-beta/chemical-substance> ;
-                                                   owl:imports <https://w3id.org/emmo/1.0.0> ;
+                                                   owl:imports <https://w3id.org/emmo/1.0.0/disciplines/chemistry> ,
+                                                               <https://w3id.org/emmo/1.0.0/disciplines/isq> ,
+                                                               <https://w3id.org/emmo/1.0.0/disciplines/materials> ,
+                                                               <https://w3id.org/emmo/1.0.0/disciplines/metrology> ,
+                                                               <https://w3id.org/emmo/1.0.0/mereocausality> ,
+                                                               <https://w3id.org/emmo/1.0.0/perspectives/persistence> ,
+                                                               <https://w3id.org/emmo/1.0.0/reference/physicalistic> ;
                                                    dcterms:abstract "This ontology provides terms for chemical substances that can be referenced and re-used other resources."@en ;
                                                    dcterms:bibliographicCitation "https://zenodo.org/doi/10.5281/zenodo.10254978" ;
                                                    dcterms:contributor <https://orcid.org/0000-0002-1560-809X> ;
@@ -177,6 +183,14 @@ emmo:EMMO_f652e7d2_0b33_4d10_8d0f_2f70089982ba rdf:type owl:AnnotationProperty ;
 
 
 #################################################################
+#    Datatypes
+#################################################################
+
+###  http://www.w3.org/2001/XMLSchema#date
+xsd:date rdf:type rdfs:Datatype .
+
+
+#################################################################
 #    Object Properties
 #################################################################
 
@@ -204,6 +218,13 @@ emmo:EMMO_f652e7d2_0b33_4d10_8d0f_2f70089982ba rdf:type owl:AnnotationProperty ;
 schema:Person rdf:type owl:Class ;
               skos:prefLabel "Person"@en ;
               emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "the schema.org term for a Person"@en .
+
+
+###  https://w3id.org/emmo#EMMO_5cb107ba_7daa_46dd_8f9f_da22a6eac676
+emmo:EMMO_5cb107ba_7daa_46dd_8f9f_da22a6eac676 rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty emmo:EMMO_17e27c22_37e1_468c_9dd7_95e137f73e7f ;
+                                                                 owl:someValuesFrom <https://w3id.org/emmo/domain/electrochemistry#electrochemistry_a7b05629_80d7_402b_be1a_69933d24c4cb>
+                                                               ] .
 
 
 ###  https://w3id.org/emmo/domain//chemical-substance#substance_69ce48e4_23e3_4758_84ae_f00ed3f79518
@@ -672,7 +693,11 @@ schema:Person rdf:type owl:Class ;
 
 ###  https://w3id.org/emmo/domain/chemical-substance#substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1
 :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 rdf:type owl:Class ;
-                                                rdfs:subClassOf emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ;
+                                                rdfs:subClassOf emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ,
+                                                                [ rdf:type owl:Restriction ;
+                                                                  owl:onProperty emmo:EMMO_a8bd7094_6b40_47af_b1f4_a69d81a3afbd ;
+                                                                  owl:someValuesFrom emmo:EMMO_2031516a_2be7_48e8_9af7_7e1270e308fe
+                                                                ] ;
                                                 skos:prefLabel "Solvent" ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q146505" ;
                                                 emmo:EMMO_50c298c2_55a2_4068_b3ac_4e948c33181f "https://www.electropedia.org/iev/iev.nsf/display?openform&ievref=114-01-06" ;
@@ -1870,7 +1895,11 @@ schema:Person rdf:type owl:Class ;
 
 ###  https://w3id.org/emmo/domain/chemical-substance#substance_3899a9c9_9b34_443e_8ce6_0257589bb38a
 :substance_3899a9c9_9b34_443e_8ce6_0257589bb38a rdf:type owl:Class ;
-                                                rdfs:subClassOf emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ;
+                                                rdfs:subClassOf emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ,
+                                                                [ rdf:type owl:Restriction ;
+                                                                  owl:onProperty emmo:EMMO_a8bd7094_6b40_47af_b1f4_a69d81a3afbd ;
+                                                                  owl:someValuesFrom emmo:EMMO_2031516a_2be7_48e8_9af7_7e1270e308fe
+                                                                ] ;
                                                 skos:prefLabel "Solute"@en ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q1079788" ;
                                                 emmo:EMMO_50c298c2_55a2_4068_b3ac_4e948c33181f "https://www.electropedia.org/iev/iev.nsf/display?openform&ievref=114-01-05" ;
@@ -8449,8 +8478,8 @@ schema:Person rdf:type owl:Class ;
 ###  https://w3id.org/emmo/domain/chemical-substance#substance_fef7bf51_9187_4c3b_94e8_91ac7593fd21
 :substance_fef7bf51_9187_4c3b_94e8_91ac7593fd21 rdf:type owl:Class ;
                                                 rdfs:subClassOf :substance_0160f86c_e567_40d4_a457_25cf170e7ef2 ;
-                                                skos:altLabel "SiO2" ,
-                                                              "Silica"@en ;
+                                                skos:altLabel "Silica"@en ,
+                                                              "SiO2" ;
                                                 skos:prefLabel "SiliconDioxide"@en ;
                                                 emmo:EMMO_26bf1bef_d192_4da6_b0eb_d2209698fb54 "https://www.wikidata.org/wiki/Q116269" ;
                                                 emmo:EMMO_371f5265_fa29_4081_b722_2c530b1fdddb "https://pubchem.ncbi.nlm.nih.gov/compound/24261" ;
@@ -8597,4 +8626,4 @@ schema:Person rdf:type owl:Class ;
 emmo:material_c5c9cf9f_252e_4b28_90f6_56b500db67fc skos:prefLabel "deprecate_OrganicCompound"@en .
 
 
-###  Generated by the OWL API (version 4.5.9.2019-02-01T07:24:44Z) https://github.com/owlcs/owlapi
+###  Generated by the OWL API (version 4.5.29.2024-05-13T12:11:03Z) https://github.com/owlcs/owlapi

--- a/chemical-substance.ttl
+++ b/chemical-substance.ttl
@@ -16,11 +16,11 @@
 
 <https://w3id.org/emmo/domain/chemical-substance> rdf:type owl:Ontology ;
                                                    owl:versionIRI <https://w3id.org/emmo/domain/chemical-substance/0.11.0-beta/chemical-substance> ;
-                                                   owl:imports <https://w3id.org/emmo/1.0.0/disciplines/chemistry> ,
+                                                   owl:imports <https://w3id.org/emmo/1.0.0/mereocausality> ,
+                                                               <https://w3id.org/emmo/1.0.0/disciplines/chemistry> ,
                                                                <https://w3id.org/emmo/1.0.0/disciplines/isq> ,
                                                                <https://w3id.org/emmo/1.0.0/disciplines/materials> ,
                                                                <https://w3id.org/emmo/1.0.0/disciplines/metrology> ,
-                                                               <https://w3id.org/emmo/1.0.0/mereocausality> ,
                                                                <https://w3id.org/emmo/1.0.0/perspectives/persistence> ,
                                                                <https://w3id.org/emmo/1.0.0/reference/physicalistic> ;
                                                    dcterms:abstract "This ontology provides terms for chemical substances that can be referenced and re-used other resources."@en ;
@@ -194,19 +194,33 @@ xsd:date rdf:type rdfs:Datatype .
 #    Object Properties
 #################################################################
 
+###  https://w3id.org/emmo#EMMO_3c7f239f_e833_4a2b_98a1_c88831770c1b
+emmo:EMMO_3c7f239f_e833_4a2b_98a1_c88831770c1b owl:inverseOf :electrochemistry_57fcaa3b_7c1f_4114_84cd_a18932b2c56b .
+
+
+###  https://w3id.org/emmo/domain/chemical-substance#electrochemistry_57fcaa3b_7c1f_4114_84cd_a18932b2c56b
+:electrochemistry_57fcaa3b_7c1f_4114_84cd_a18932b2c56b rdf:type owl:ObjectProperty ;
+                                                       rdfs:subPropertyOf emmo:EMMO_928f6ec2_7564_4c8d_9a10_7a601fa89602 ;
+                                                       rdfs:domain emmo:EMMO_f76884f7_964e_488e_9bb7_1b2453e9e817 ;
+                                                       rdfs:range emmo:EMMO_65a007dc_2550_46b0_b394_3346c67fbb69 ;
+                                                       rdfs:label "isComponentOf"@en .
+
+
 ###  https://w3id.org/emmo/domain/electrochemistry#electrochemistry_808e94df_e002_4e64_a6db_182ed75078c6
 <https://w3id.org/emmo/domain/electrochemistry#electrochemistry_808e94df_e002_4e64_a6db_182ed75078c6> rdf:type owl:ObjectProperty ;
-                                                                                                      rdfs:subPropertyOf emmo:EMMO_dba27ca1_33c9_4443_a912_1519ce4c39ec ;
+                                                                                                      rdfs:subPropertyOf emmo:EMMO_3c7f239f_e833_4a2b_98a1_c88831770c1b ;
                                                                                                       rdfs:domain emmo:EMMO_2031516a_2be7_48e8_9af7_7e1270e308fe ;
-                                                                                                      rdfs:range emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ;
+                                                                                                      rdfs:range emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ,
+                                                                                                                 emmo:EMMO_f76884f7_964e_488e_9bb7_1b2453e9e817 ;
                                                                                                       skos:prefLabel "hasSolvent"@en .
 
 
 ###  https://w3id.org/emmo/domain/electrochemistry#electrochemistry_8784ef24_320b_4a3d_b200_654aec6c271c
 <https://w3id.org/emmo/domain/electrochemistry#electrochemistry_8784ef24_320b_4a3d_b200_654aec6c271c> rdf:type owl:ObjectProperty ;
-                                                                                                      rdfs:subPropertyOf emmo:EMMO_dba27ca1_33c9_4443_a912_1519ce4c39ec ;
+                                                                                                      rdfs:subPropertyOf emmo:EMMO_3c7f239f_e833_4a2b_98a1_c88831770c1b ;
                                                                                                       rdfs:domain emmo:EMMO_2031516a_2be7_48e8_9af7_7e1270e308fe ;
-                                                                                                      rdfs:range emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ;
+                                                                                                      rdfs:range emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ,
+                                                                                                                 emmo:EMMO_f76884f7_964e_488e_9bb7_1b2453e9e817 ;
                                                                                                       skos:prefLabel "hasSolute"@en .
 
 
@@ -220,9 +234,20 @@ schema:Person rdf:type owl:Class ;
               emmo:EMMO_967080e5_2f42_4eb2_a3a9_c58143e835f9 "the schema.org term for a Person"@en .
 
 
+###  https://w3id.org/emmo#EMMO_2031516a_2be7_48e8_9af7_7e1270e308fe
+emmo:EMMO_2031516a_2be7_48e8_9af7_7e1270e308fe rdfs:subClassOf [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty <https://w3id.org/emmo/domain/electrochemistry#electrochemistry_808e94df_e002_4e64_a6db_182ed75078c6> ;
+                                                                 owl:someValuesFrom :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1
+                                                               ] ,
+                                                               [ rdf:type owl:Restriction ;
+                                                                 owl:onProperty <https://w3id.org/emmo/domain/electrochemistry#electrochemistry_8784ef24_320b_4a3d_b200_654aec6c271c> ;
+                                                                 owl:someValuesFrom :substance_3899a9c9_9b34_443e_8ce6_0257589bb38a
+                                                               ] .
+
+
 ###  https://w3id.org/emmo#EMMO_5cb107ba_7daa_46dd_8f9f_da22a6eac676
 emmo:EMMO_5cb107ba_7daa_46dd_8f9f_da22a6eac676 rdfs:subClassOf [ rdf:type owl:Restriction ;
-                                                                 owl:onProperty emmo:EMMO_17e27c22_37e1_468c_9dd7_95e137f73e7f ;
+                                                                 owl:onProperty <https://w3id.org/emmo/domain/electrochemistry#electrochemistry_808e94df_e002_4e64_a6db_182ed75078c6> ;
                                                                  owl:someValuesFrom <https://w3id.org/emmo/domain/electrochemistry#electrochemistry_a7b05629_80d7_402b_be1a_69933d24c4cb>
                                                                ] .
 
@@ -695,7 +720,7 @@ emmo:EMMO_5cb107ba_7daa_46dd_8f9f_da22a6eac676 rdfs:subClassOf [ rdf:type owl:Re
 :substance_0f2f65a7_5cc4_4c86_a4d0_676771c646f1 rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ,
                                                                 [ rdf:type owl:Restriction ;
-                                                                  owl:onProperty emmo:EMMO_a8bd7094_6b40_47af_b1f4_a69d81a3afbd ;
+                                                                  owl:onProperty :electrochemistry_57fcaa3b_7c1f_4114_84cd_a18932b2c56b ;
                                                                   owl:someValuesFrom emmo:EMMO_2031516a_2be7_48e8_9af7_7e1270e308fe
                                                                 ] ;
                                                 skos:prefLabel "Solvent" ;
@@ -1897,7 +1922,7 @@ emmo:EMMO_5cb107ba_7daa_46dd_8f9f_da22a6eac676 rdfs:subClassOf [ rdf:type owl:Re
 :substance_3899a9c9_9b34_443e_8ce6_0257589bb38a rdf:type owl:Class ;
                                                 rdfs:subClassOf emmo:EMMO_e2b11f6a_4191_427e_9844_2e0ac88dfc8b ,
                                                                 [ rdf:type owl:Restriction ;
-                                                                  owl:onProperty emmo:EMMO_a8bd7094_6b40_47af_b1f4_a69d81a3afbd ;
+                                                                  owl:onProperty :electrochemistry_57fcaa3b_7c1f_4114_84cd_a18932b2c56b ;
                                                                   owl:someValuesFrom emmo:EMMO_2031516a_2be7_48e8_9af7_7e1270e308fe
                                                                 ] ;
                                                 skos:prefLabel "Solute"@en ;

--- a/chemical-substance.ttl
+++ b/chemical-substance.ttl
@@ -15,21 +15,15 @@
 @base <https://w3id.org/emmo/domain/chemical-substance#> .
 
 <https://w3id.org/emmo/domain/chemical-substance> rdf:type owl:Ontology ;
-                                                   owl:versionIRI <https://w3id.org/emmo/domain/chemical-substance/0.11.0-beta/chemical-substance> ;
-                                                   owl:imports <https://w3id.org/emmo/1.0.0/mereocausality> ,
-                                                               <https://w3id.org/emmo/1.0.0/disciplines/chemistry> ,
-                                                               <https://w3id.org/emmo/1.0.0/disciplines/isq> ,
-                                                               <https://w3id.org/emmo/1.0.0/disciplines/materials> ,
-                                                               <https://w3id.org/emmo/1.0.0/disciplines/metrology> ,
-                                                               <https://w3id.org/emmo/1.0.0/perspectives/persistence> ,
-                                                               <https://w3id.org/emmo/1.0.0/reference/physicalistic> ;
+                                                   owl:versionIRI <https://w3id.org/emmo/domain/chemical-substance/0.12.0-beta/chemical-substance> ;
+                                                   owl:imports <https://w3id.org/emmo/1.0.0> ;
                                                    dcterms:abstract "This ontology provides terms for chemical substances that can be referenced and re-used other resources."@en ;
                                                    dcterms:bibliographicCitation "https://zenodo.org/doi/10.5281/zenodo.10254978" ;
                                                    dcterms:contributor <https://orcid.org/0000-0002-1560-809X> ;
                                                    dcterms:created "2023-09-28"^^xsd:date ;
                                                    dcterms:creator <https://orcid.org/0000-0002-8758-6109> ;
-                                                   dcterms:issued "2025-02-06"^^xsd:date ;
-                                                   dcterms:modified "2025-02-06"^^xsd:date ;
+                                                   dcterms:issued "2025-04-06"^^xsd:date ;
+                                                   dcterms:modified "2025-04-06"^^xsd:date ;
                                                    dcterms:publisher "EMMO" ;
                                                    dcterms:source " " ;
                                                    dcterms:title "Chemical Substance Domain Ontology"@en ;
@@ -37,8 +31,8 @@
                                                    vann:preferredNamespacePrefix "chems" ;
                                                    vann:preferredNamespaceUri "https://w3id.org/emmo/domain/chemical-substance" ;
                                                    owl:backwardCompatibleWith " " ;
-                                                   owl:priorVersion "0.10.0-beta" ;
-                                                   owl:versionInfo "0.11.0-beta" ;
+                                                   owl:priorVersion "0.11.0-beta" ;
+                                                   owl:versionInfo "0.12.0-beta" ;
                                                    foaf:logo " " .
 
 #################################################################


### PR DESCRIPTION
The ontology currently imports the whole EMMO. In this commit, `owl:imports` point only to the EMMO modules effectively used.
An axiom is added to the classes Solvent and Solute that states:
`isPartOf some Solution`.
A similar axiom is added to `emmo:AqueousSolution` stating:
`hasPart some water`