### PR TITLE
Added workflows CD for updating gh-pages and creating releases

### DIFF
--- a/.github/workflows/cd_ghpages.yml
+++ b/.github/workflows/cd_ghpages.yml
@@ -1,8 +1,13 @@
 name: Deploy on GitHub Pages
-on: push
-#on:
-#  push:
-#    branches: [master]
+#on: push
+on:
+  push:
+    branches:
+      - master
+      - main
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
+
 
 env:
   ONTOLOGY_NAME: chemical-substance

--- a/.github/workflows/cd_ghpages.yml
+++ b/.github/workflows/cd_ghpages.yml
@@ -30,14 +30,12 @@ jobs:
     - name: Install EMMOntoPy
       run: |
         pip install --upgrade pip
-        #pip install EMMOntoPy
-        pip install -U git+https://github.com/emmo-repo/EMMOntoPy.git@annotating
+        pip install "EMMOntoPy[ontodoc] @ git+https://github.com/emmo-repo/EMMOntoPy.git@master"
 
-    - name: Install temgo and tripper
+    - name: Install tripper
       run: |
         pip install .
-        pip install tripper[datadoc]
-        pip install -U git+https://github.com/EMMC-ASBL/tripper.git@master
+        pip install "tripper[datadoc] @ git+https://github.com/EMMC-ASBL/tripper.git@master"
 
     - name: Install ROBOT
       run: |

--- a/.github/workflows/cd_ghpages.yml
+++ b/.github/workflows/cd_ghpages.yml
@@ -1,12 +1,12 @@
 name: Deploy on GitHub Pages
-#on: push
-on:
-  push:
-    branches:
-      - master
-      - main
-      - '[0-9]+.[0-9]+.[0-9]+'
-      - '[0-9]+.[0-9]+.[0-9]+-*'
+on: push
+#on:
+#  push:
+#    branches:
+#      - master
+#      - main
+#      - '[0-9]+.[0-9]+.[0-9]+'
+#      - '[0-9]+.[0-9]+.[0-9]+-*'
 
 
 env:
@@ -32,14 +32,12 @@ jobs:
       with:
         python-version: 3.14
 
-    - name: Install EMMOntoPy
+    - name: Install EMMOntoPy and tripper
       run: |
         pip install --upgrade pip
-        pip install "EMMOntoPy[ontodoc] @ git+https://github.com/emmo-repo/EMMOntoPy.git@master"
-
-    - name: Install tripper
-      run: |
-        pip install "tripper[datadoc] @ git+https://github.com/EMMC-ASBL/tripper.git@master"
+        pip install \
+            "EMMOntoPy[ontodoc] @ git+https://github.com/emmo-repo/EMMOntoPy.git@master" \
+            "tripper[datadoc] @ git+https://github.com/EMMC-ASBL/tripper.git@master"
 
     - name: Install ROBOT
       run: |

--- a/.github/workflows/cd_ghpages.yml
+++ b/.github/workflows/cd_ghpages.yml
@@ -1,12 +1,14 @@
 name: Deploy on GitHub Pages
-on: push
-#on:
-#  push:
-#    branches:
-#      - master
-#      - main
-#      - '[0-9]+.[0-9]+.[0-9]+'
-#      - '[0-9]+.[0-9]+.[0-9]+-*'
+
+# Only run this workflow on push to a release branch or master
+# on: push
+on:
+  push:
+    branches:
+      - master
+      - main
+      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+-*'
 
 
 env:
@@ -57,7 +59,7 @@ jobs:
         mkdir build
         cp README.md LICENSE build/.
 
-    - name: Create ${ONTOLOGY_NAME}-dependencies
+    - name: Create dependencies on github pages
       run: |
         ontoconvert \
             -saw \

--- a/.github/workflows/cd_ghpages.yml
+++ b/.github/workflows/cd_ghpages.yml
@@ -54,7 +54,7 @@ jobs:
         mkdir build
         cp README.md LICENSE build/.
 
-    - name: Copy readme and license files to gh-pages
+    - name: Create ${ONTOLOGY_NAME}-dependencies
       run: |
         ontoconvert \
             -saw \

--- a/.github/workflows/cd_ghpages.yml
+++ b/.github/workflows/cd_ghpages.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: 3.14
 
     - name: Install EMMOntoPy
       run: |
@@ -34,7 +34,6 @@ jobs:
 
     - name: Install tripper
       run: |
-        pip install .
         pip install "tripper[datadoc] @ git+https://github.com/EMMC-ASBL/tripper.git@master"
 
     - name: Install ROBOT

--- a/.github/workflows/cd_ghpages.yml
+++ b/.github/workflows/cd_ghpages.yml
@@ -1,8 +1,8 @@
 name: Deploy on GitHub Pages
-#on: push
-on:
-  push:
-    branches: [master]
+on: push
+#on:
+#  push:
+#    branches: [master]
 
 env:
   ONTOLOGY_NAME: chemical-substance

--- a/.github/workflows/cd_ghpages.yml
+++ b/.github/workflows/cd_ghpages.yml
@@ -1,0 +1,136 @@
+name: Deploy on GitHub Pages
+#on: push
+on:
+  push:
+    branches: [master]
+
+env:
+  ONTOLOGY_NAME: chemical-substance
+  ONTOLOGY_PREFIX: chems
+  ONTOLOGY_IRI: https://w3id.org/emmo/domain/chemical-substance
+
+permissions:
+  contents: write
+
+
+jobs:
+  deploy-on-ghpages:
+    #concurrency: ci-${{ github.ref }}  # Recommended if you intend to make multiple deployments in quick succession.
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.11
+
+    - name: Install EMMOntoPy
+      run: |
+        pip install --upgrade pip
+        #pip install EMMOntoPy
+        pip install -U git+https://github.com/emmo-repo/EMMOntoPy.git@annotating
+
+    - name: Install temgo and tripper
+      run: |
+        pip install .
+        pip install tripper[datadoc]
+        pip install -U git+https://github.com/EMMC-ASBL/tripper.git@master
+
+    - name: Install ROBOT
+      run: |
+        mkdir bin
+        wget -nv https://github.com/ontodev/robot/releases/download/v1.9.6/robot.jar
+        mv robot.jar bin/.
+        curl https://raw.githubusercontent.com/ontodev/robot/master/bin/robot > bin/robot
+        chmod +x bin/robot
+        ls -l bin/
+
+    - name: Download Widoco
+      run: |
+        wget --quiet https://github.com/dgarijo/Widoco/releases/download/v1.4.25/widoco-1.4.25-jar-with-dependencies_JDK-17.jar
+
+    - name: Copy readme and license files to gh-pages
+      run: |
+        mkdir build
+        cp README.md LICENSE build/.
+
+    - name: Copy readme and license files to gh-pages
+      run: |
+        ontoconvert \
+            -saw \
+            --namespace="emmo:https://w3id.org/emmo#" \
+            --namespace="${ONTOLOGY_PREFIX}:${ONTOLOGY_IRI}#" \
+            ${ONTOLOGY_NAME}-dependencies.ttl \
+            build/${ONTOLOGY_NAME}-dependencies.ttl
+
+    - name: Create squashed ontology
+      run: |
+        ontoconvert \
+            -sawe \
+            --namespace="emmo:https://w3id.org/emmo#" \
+            --namespace="${ONTOLOGY_PREFIX}:${ONTOLOGY_IRI}#" \
+            --base-iri="${ONTOLOGY_IRI}#" \
+            --iri="${ONTOLOGY_IRI}" \
+            ${ONTOLOGY_NAME}.ttl \
+            build/${ONTOLOGY_NAME}.ttl
+
+    - name: Create ontology for used later for generating documentation
+      run: |
+        ontoconvert \
+            -awe \
+            --namespace="emmo:https://w3id.org/emmo#" \
+            --namespace="${ONTOLOGY_PREFIX}:${ONTOLOGY_IRI}#" \
+            --base-iri="${ONTOLOGY_IRI}#" \
+            --iri="${ONTOLOGY_IRI}" \
+            --copy-annotation="elucidation-->http://purl.org/dc/terms/description" \
+            --copy-annotation="prefLabel-->http://www.w3.org/2000/01/rdf-schema#label" \
+            ${ONTOLOGY_NAME}.ttl \
+            build/${ONTOLOGY_NAME}-doc.ttl
+
+    - name: Create inferred ontology
+      run: |
+        # Running HermiT via ontoconvert fails with custom datatypes.
+        # Use ROBOT instead.
+        #
+        #ontoconvert \
+        #    -sawe \
+        #    --base-iri="${ONTOLOGY_IRI}#" \
+        #    --iri="${ONTOLOGY_IRI}" \
+        #    --infer=HermiT \
+        #    ${ONTOLOGY_NAME}.ttl \
+        #    build/${ONTOLOGY_NAME}-inferred.ttl
+        #
+        bin/robot reason \
+            --reasoner HermiT \
+            --input build/${ONTOLOGY_NAME}.ttl \
+            --output build/${ONTOLOGY_NAME}-inferred.ttl
+
+#    - name: Generate markdown documentation of all keywords
+#      run: |
+#        keywords -i build/${ONTOLOGY_NAME}-doc.ttl --keywords build/${ONTOLOGY_NAME}.md --namespace-filter=${ONTOLOGY_IRI} --redefine=allow
+
+    - name: Generate Widoco documentation
+      run: |
+        java -jar widoco-1.4.25-jar-with-dependencies_JDK-17.jar \
+            -ontFile build/${ONTOLOGY_NAME}-doc.ttl \
+            -outFolder build/widoco \
+            -getOntologyMetadata \
+            -oops \
+            -rewriteAll \
+            -saveConfig build/widoco/widoco.conf \
+            - webVowl \
+            -licensius \
+            -includeAnnotationProperties
+
+
+
+    - name: Deploy to GitHub Pages
+      uses: JamesIves/github-pages-deploy-action@v4
+      with:
+        folder: build
+        branch: gh-pages
+        clean: false
+        single-commit: true

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -1,0 +1,40 @@
+name: Release new version
+
+on:
+  release:
+    types: [published]
+
+env:
+  ONTOLOGY_NAME: chemical-substance
+  TAG: ${{ github.ref_name }}
+
+permissions:
+  contents: write
+
+jobs:
+  release_version:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout gh-pages
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+
+      - name: Create and copy generated files to versions/
+        run: |
+          mkdir -p versions/${TAG#v}
+          cp -f \
+              README.md \
+              ${ONTOLOGY_NAME}.ttl \
+              ${ONTOLOGY_NAME}-dependencies.ttl \
+              ${ONTOLOGY_NAME}-inferred.ttl \
+              versions/${TAG#v}/.
+
+      - name: Push to gh-pages
+        run: |
+          git config --global user.email "${ONTOLOGY_NAME}@emmc.eu"
+          git config --global user.name "${ONTOLOGY_NAME}"
+          git add versions/${TAG#v}
+          git commit -m "Release version ${TAG#v}"
+          git push origin gh-pages

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -1,69 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <catalog prefer="public" xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
-    <uri id="Imports Wizard Entry" name="https://w3id.org/emmo/1.0.2" uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/emmo.ttl"/>
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=false, version=2" prefer="public" xml:base="">
         <uri name="https://w3id.org/emmo/domain/chemical-substance/0.13.2/chemical-substance" uri="./chemical-substance.ttl"/>
-        <uri name="https://w3id.org/emmo/domain/chemical-substance/0.13.2/dependencies" uri="./chemical-substance-dependencies.ttl"/>
 
-        <uri name="https://w3id.org/emmo/1.0.2"                                 uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/emmo.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/contributors"                    uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/contributors.ttl"/>
+        <!-- Uncomment the below if you can't redirections doesn't work -->
+        <!--
+        <uri name="https://w3id.org/emmo/domain/chemical-substance/0.13.2/dependencies" uri="https://emmo-repo.github.io/domain-chemical-substance/versions/0.13.2/chemical-substance-dependencies.ttl"/> ;
+        -->
 
-        <uri name="https://w3id.org/emmo/1.0.2/mereocausality"                  uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/mereocausality/mereocausality.ttl"/>
-
-        <uri name="https://w3id.org/emmo/1.0.2/perspectives"                    uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/perspectives/perspectives.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/perspectives/perspective"        uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/perspectives/perspective.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/perspectives/reductionistic"     uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/perspectives/reductionistic.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/perspectives/holistic"           uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/perspectives/holistic.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/perspectives/structural"         uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/perspectives/structural.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/perspectives/persistence"        uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/perspectives/persistence.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/perspectives/contrast"           uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/perspectives/contrast.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/perspectives/semiotics"          uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/perspectives/semiotics.ttl"/>
-
-        <uri name="https://w3id.org/emmo/1.0.2/reference"                    uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/reference/reference.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/reference/persholistic"       uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/reference/persholistic.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/reference/symbolic"           uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/reference/symbolic.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/reference/information"        uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/reference/information.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/reference/workflow"           uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/reference/workflow.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/reference/physicalistic"      uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/reference/physicalistic.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/reference/standardmodel-full" uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/reference/standardmodel-full.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/reference/standardmodel"      uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/reference/standardmodel.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/reference/data"               uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/reference/data.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/reference/agency"             uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/reference/agency.ttl"/>
-
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines"                     uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/disciplines.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/chemistry"           uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/chemistry.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/computerscience"     uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/computerscience.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/manufacturing"       uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/manufacturing.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/materials"           uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/materials.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/math"                uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/math.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/models"              uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/models.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/periodictable"       uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/periodictable.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/perceptual"          uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/perceptual.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/geometrical"         uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/geometrical.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/properties"         uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/properties.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/dataset"             uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/dataset.ttl"/>
-
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/metrology"           uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/metrology.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/isq"                 uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/isq.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/sisystem"            uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/sisystem.ttl"/>
-
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/units"                         uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/units/units.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/units/sidimensionalunits"      uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/units/sidimensionalunits.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/units/siunits"                 uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/units/siunits.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/units/prefixedsiunits"         uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/units/prefixedsiunits.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/units/coherentsiunits"         uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/units/coherentsiunits.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/units/noncoherentsiunits"      uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/units/noncoherentsiunits.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/units/siacceptedspecialunits"  uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/units/siacceptedspecialunits.ttl"/>
-
-        <!-- Imported by emmo-full  -->
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/units/siacceptedunits"         uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/units/siacceptedunits.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/units/specialunits"            uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/units/specialunits.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/units/otherunits"              uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/units/otherunits.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/units/unclassifiedunits"       uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/units/unclassifiedunits.ttl"/>
-
-        <!-- Deprecated  -->
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/units/unitsextension"          uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/units/unitsextension.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/units/prefixedunits"           uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/units/prefixedunits.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/disciplines/units/deprecated"              uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/disciplines/units/deprecated.ttl"/>
     </group>
 </catalog>

--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -16,7 +16,7 @@
         <uri name="https://w3id.org/emmo/1.0.2/perspectives/holistic"           uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/perspectives/holistic.ttl"/>
         <uri name="https://w3id.org/emmo/1.0.2/perspectives/structural"         uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/perspectives/structural.ttl"/>
         <uri name="https://w3id.org/emmo/1.0.2/perspectives/persistence"        uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/perspectives/persistence.ttl"/>
-        <uri name="https://w3id.org/emmo/1.0.2/perspectives/contrast"           uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/perspectives/contrast.ttl"/>        
+        <uri name="https://w3id.org/emmo/1.0.2/perspectives/contrast"           uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/perspectives/contrast.ttl"/>
         <uri name="https://w3id.org/emmo/1.0.2/perspectives/semiotics"          uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/perspectives/semiotics.ttl"/>
 
         <uri name="https://w3id.org/emmo/1.0.2/reference"                    uri="https://raw.githubusercontent.com/emmo-repo/emmo/1.0.2/reference/reference.ttl"/>

--- a/chemical-substance-dependencies.ttl
+++ b/chemical-substance-dependencies.ttl
@@ -7,3 +7,7 @@
         <https://w3id.org/emmo/1.0.2/disciplines/manufacturing> ,
         <https://w3id.org/emmo/1.0.2/disciplines/chemistry> ,
         <https://w3id.org/emmo/1.0.2/disciplines/materials> .
+
+# To get rid of foaf:Person and foaf:Organization at the top level, also import these:
+#    <https://w3id.org/emmo/1.0.2/disciplines/agency> ,
+#    <https://w3id.org/emmo/1.0.2/contributors-mappings> ,

--- a/chemical-substance-dependencies.ttl
+++ b/chemical-substance-dependencies.ttl
@@ -4,4 +4,6 @@
 <https://w3id.org/emmo/domain/chemical-substance/dependencies> rdf:type owl:Ontology ;
     owl:versionIRI <https://w3id.org/emmo/domain/chemical-substance/0.13.2/dependencies> ;
     owl:imports
-        <https://w3id.org/emmo/1.0.2> .
+        <https://w3id.org/emmo/1.0.2/disciplines/manufacturing> ,
+        <https://w3id.org/emmo/1.0.2/disciplines/chemistry> ,
+        <https://w3id.org/emmo/1.0.2/disciplines/materials> .


### PR DESCRIPTION
Generate resolved dependencies on GitHub Pages. 

Changes in this PR:
- Only the EMMO modules needed by chemical-substance are now imported. If you want everything from EMMO, import <https://w3id.org/emmo/mlo> or <https://w3id.org/emmo/emax> instead in the dependencies file.
- All dependencies are squashed into a single file stored on GitHub Pages. Loading chemical-substance is therefor much faster now, with no duplicate annotations.
- Cleaned up the catalog file with no explicit references to EMMO. This simplifies maintenance will ensure that chemical-substance is unaffected by the renaming of mereocausality module in EMMO 1.0.2. 
  If you have problems importing https://w3id.org/emmo/domain/chemical-substance/0.13.2/dependencies, Uncomment explicit import from GitHub in the catalog file. 
- Added `cd_ghpages.yml` workflow. This workflow updates github pages on merge to master. It will create a squashed version of chemical-substance-dependencies.ttl file on github pages with all imports resolved.
- Added `cd_release` workflow. It creates a version sub-directory on github pages for new releases.
 