### PR TITLE
ci(docs): allow manual dispatch to redeploy docs and backfill versions/ archive

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - '*'  # run on all PRs
+  workflow_dispatch:  # manual runs: redeploy docs and backfill the versions/ archive
 
 env:
   CONFIG_PATH: config.yml
@@ -181,14 +182,14 @@ jobs:
         git ls-files --others --exclude-standard
 
     - name: Stash Changes Before Pull
-      if: github.event_name == 'push'
+      if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
       run: |
         git stash --include-untracked
         git pull origin main --rebase
         git stash pop || echo "No stash to apply"
 
     - name: Push Changes
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
       run: git push origin HEAD:main
 
     - name: Load TTL Files into ENV
@@ -215,7 +216,7 @@ jobs:
         done
 
     - name: Fetch All Tags and Copy TTL Files
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      if: (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
@@ -255,7 +256,7 @@ jobs:
         path: docs/_build/html/
   
     - name: Deploy
-      if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+      if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

`docs.yml` only ran the deploy and per-version `versions/` backfill on push to the default branch, so there was no way to trigger a fresh docs run on demand — e.g. to pull a newly attached per-version `*-inferred.ttl` release asset into `versions/<tag>/`.

## Changes
- Add a `workflow_dispatch` trigger.
- Extend the stash/pull, push-generated-docs, versions-archive, and deploy steps to also run on `workflow_dispatch` (still gated to the default branch), so a manual run performs a full redeploy identical to a push-to-default run.

## Effect
Merging this runs `docs` on `main`, which backfills `versions/0.14.2/` from the 0.14.2 release's inferred asset. Going forward, Actions → docs → Run workflow can redeploy on demand.